### PR TITLE
fix: ignoring exception ResizeObserver loop exceptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -330,6 +330,9 @@ async function connect (connectOptions: ConnectOptions) {
   }
   const handleError = (err) => {
     console.error(err)
+    if (err === 'ResizeObserver loop completed with undelivered notifications.') {
+      return
+    }
     errorAbortController.abort()
     if (isCypress()) throw err
     miscUiState.hasErrors = true


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c220ed09-11d6-486f-b034-34d9e5b07382)

![image](https://github.com/user-attachments/assets/a9013023-173f-48ca-92d4-082befb8ff6b)

I faced this issue in my local setup, and googled for it, and mainly found that the issue can be ignored, what i do now in this PR.

Maybe it is in general not the best idea to let every error disconnect the client