### PR TITLE
fix: do not interact with blocks behind entities

### DIFF
--- a/src/worldInteractions.ts
+++ b/src/worldInteractions.ts
@@ -221,7 +221,12 @@ class WorldInteraction {
   // todo this shouldnt be done in the render loop, migrate the code to dom events to avoid delays on lags
   update () {
     const inSpectator = bot.game.gameMode === 'spectator'
-    const cursorBlock = inSpectator && !options.showCursorBlockInSpectator ? null : bot.blockAtCursor(5)
+    const entity = getEntityCursor()
+    let cursorBlock = inSpectator && !options.showCursorBlockInSpectator ? null : bot.blockAtCursor(5)
+    if (entity) {
+      cursorBlock = null
+    }
+
     let cursorBlockDiggable = cursorBlock
     if (cursorBlock && !bot.canDigBlock(cursorBlock) && bot.game.gameMode !== 'creative') cursorBlockDiggable = null
 


### PR DESCRIPTION
that way, when an entity is detected, the cursorBlock is set to null, preventing the ray-tracer from interacting with any blocks behind the entity