### PR TITLE
feat: basic support for text_display entity

### DIFF
--- a/prismarine-viewer/viewer/lib/entities.ts
+++ b/prismarine-viewer/viewer/lib/entities.ts
@@ -29,17 +29,27 @@ function getUsernameTexture (username: string, { fontFamily = 'sans-serif' }: an
   const padding = 5
   ctx.font = `${fontSize}px ${fontFamily}`
 
-  const textWidth = ctx.measureText(username).width + padding * 2
+  const lines = String(username).split('\n')
+
+  let textWidth = 0
+  for (const line of lines) {
+    const width = ctx.measureText(line).width + padding * 2
+    if (width > textWidth) textWidth = width
+  }
 
   canvas.width = textWidth
-  canvas.height = fontSize + padding * 2
+  canvas.height = (fontSize + padding * 2) * lines.length
 
   ctx.fillStyle = 'rgba(0, 0, 0, 0.3)'
   ctx.fillRect(0, 0, canvas.width, canvas.height)
 
   ctx.font = `${fontSize}px ${fontFamily}`
   ctx.fillStyle = 'white'
-  ctx.fillText(username, padding, fontSize)
+  let i = 0
+  for (const line of lines) {
+    i++
+    ctx.fillText(line, padding + (textWidth - ctx.measureText(line).width) / 2, fontSize * i)
+  }
 
   return canvas
 }
@@ -454,6 +464,7 @@ export class Entities extends EventEmitter {
     // ---
     // not player
     const displayText = entity.metadata?.[3] && this.parseEntityLabel(entity.metadata[2])
+      || entity.metadata?.[23] && this.parseEntityLabel(entity.metadata[23]) // text displays
     if (entity.name !== 'player' && displayText) {
       addNametag({ ...entity, username: displayText }, this.entitiesOptions, this.entities[entity.id].children.find(c => c.name === 'mesh'))
     }

--- a/prismarine-viewer/viewer/lib/entity/EntityMesh.js
+++ b/prismarine-viewer/viewer/lib/entity/EntityMesh.js
@@ -224,8 +224,8 @@ export const knownNotHandled = [
   'item_display', 'item_frame',
   'lightning_bolt', 'marker',
   'painting', 'spawner_minecart',
-  'spectral_arrow', 'text_display',
-  'tnt', 'trader_llama', 'zombie_horse'
+  'spectral_arrow', 'tnt',
+  'trader_llama', 'zombie_horse'
 ]
 
 export const temporaryMap = {

--- a/prismarine-viewer/viewer/lib/entity/entities.json
+++ b/prismarine-viewer/viewer/lib/entity/entities.json
@@ -16390,6 +16390,10 @@
     },
     "render_controllers": ["controller.render.strider"]
   },
+  "text_display": {
+    "identifier": "minecraft:text_display",
+    "geometry": {}
+  },
   "trident": {
     "identifier": "minecraft:thrown_trident",
     "textures": {


### PR DESCRIPTION
This adds basic rendering for the text of text displays. This doesn't include any other options like transforms, rendering modes or formatting of the text but makes them at least kinda usable on servers that use them to display important information. This is done by simply using the name tag system already built-in and expanding it to have multi-line support.

How it looks:
![image](https://github.com/user-attachments/assets/fca7a7da-8af1-42a0-9053-1cc2cf21445e)