### PR TITLE
fix mesher crash with some models

### DIFF
--- a/prismarine-viewer/viewer/lib/mesher/models.ts
+++ b/prismarine-viewer/viewer/lib/mesher/models.ts
@@ -123,8 +123,15 @@ const isCube = (block: Block) => {
   if (block.isCube) return true
   if (!block.models?.length || block.models.length !== 1) return false
   // all variants
-  return block.models[0].every(v => v.elements!.every(e => {
-    return e.from[0] === 0 && e.from[1] === 0 && e.from[2] === 0 && e.to[0] === 16 && e.to[1] === 16 && e.to[2] === 16
+  return block.models[0].every(v => v.elements?.every(e => {
+    return (
+      e.from[0] === 0 &&
+      e.from[1] === 0 &&
+      e.from[2] === 0 &&
+      e.to[0] === 16 &&
+      e.to[1] === 16 &&
+      e.to[2] === 16
+    );
   }))
 }
 


### PR DESCRIPTION
This PR fixes an issue with the current model implementation when the `element` is undefined.