### PR TITLE
fix: light blocks are rendered as unknown blocks

### DIFF
--- a/prismarine-viewer/viewer/lib/mesher/worldConstants.ts
+++ b/prismarine-viewer/viewer/lib/mesher/worldConstants.ts
@@ -1,1 +1,1 @@
-export const INVISIBLE_BLOCKS = new Set(['air', 'void_air', 'cave_air', 'barrier'])
+export const INVISIBLE_BLOCKS = new Set(['air', 'void_air', 'cave_air', 'barrier', 'light'])


### PR DESCRIPTION
### **User description**
This fixes that light blocks would show up as unknown blocks with a question mark texture when they should be invisible

The bug:
![image](https://github.com/user-attachments/assets/953ca69a-cffc-413e-adcd-6ce0f8f255dc)

After the fix:
![image](https://github.com/user-attachments/assets/5f273dc5-ea88-4a4d-bbe8-25ea7169da3d)



___

### **PR Type**
Bug fix


___

### **Description**
- Fixed rendering issue where light blocks appeared as unknown blocks.

- Added `light` to the set of invisible blocks in the mesher constants.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>worldConstants.ts</strong><dd><code>Add light blocks to invisible blocks set</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

prismarine-viewer/viewer/lib/mesher/worldConstants.ts

<li>Added <code>light</code> to the <code>INVISIBLE_BLOCKS</code> set.<br> <li> Ensures light blocks are treated as invisible.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/251/files#diff-5527e4966978a05703cd88053b55472099798a45d49b361e4685481f86525ac3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>