### PR TITLE
fix: title would not get rendered and rendering times be wrong

### DIFF
--- a/src/react/ChatProvider.tsx
+++ b/src/react/ChatProvider.tsx
@@ -21,6 +21,7 @@ export default () => {
 
   useEffect(() => {
     bot.addListener('message', (jsonMsg, position) => {
+      if (position === 'game_info') return // ignore action bar messages, they are handled by the TitleProvider
       const parts = formatMessage(jsonMsg)
 
       setMessages(m => {

--- a/src/react/Title.stories.tsx
+++ b/src/react/Title.stories.tsx
@@ -23,9 +23,9 @@ export const Primary: Story = {
       text: 'Action bar text'
     },
     transitionTimes: {
-      fadeIn: 2500,
-      stay: 17_500,
-      fadeOut: 5000
+      fadeIn: 500,
+      stay: 3500,
+      fadeOut: 1000
     }
   }
 }

--- a/src/react/Title.tsx
+++ b/src/react/Title.tsx
@@ -29,7 +29,8 @@ const Title = ({
   const [mounted, setMounted] = useState(false)
   const [useEnterTransition, setUseEnterTransition] = useState(true)
 
-  const defaultDuration = 500
+  const defaultFadeIn = 500
+  const defaultFadeOut = 1000
   const startStyle = {
     opacity: 1,
     transition: `${transitionTimes.fadeIn}ms ease-in-out all` }
@@ -54,10 +55,10 @@ const Title = ({
     <div className='title-container'>
       <Transition
         in={openTitle}
-        timeout={transitionTimes ? {
-          enter: transitionTimes.fadeIn,
-          exit: transitionTimes.fadeOut,
-        } : defaultDuration}
+        timeout={{
+          enter: transitionTimes?.fadeIn ?? defaultFadeIn,
+          exit: transitionTimes?.fadeOut ?? defaultFadeOut,
+        }}
         mountOnEnter
         unmountOnExit
         enter={useEnterTransition}
@@ -83,10 +84,10 @@ const Title = ({
       </Transition>
       <Transition
         in={openActionBar}
-        timeout={transitionTimes ? {
-          enter: transitionTimes.fadeIn,
-          exit: transitionTimes.fadeOut,
-        } : defaultDuration}
+        timeout={{
+          enter: transitionTimes?.fadeIn ?? defaultFadeIn,
+          exit: transitionTimes?.fadeOut ?? defaultFadeOut,
+        }}
         mountOnEnter
         unmountOnExit
         // enter={useEnterTransition}


### PR DESCRIPTION
### **User description**
This fixes that titles would not be displayed at all due to parsing errors of the received data.

Additionally to that the default timing was not what is actually used so that was adjusted too (the legacy action bar also does not fade in) and the the `game_info` message type which should only display in action bar was sent to chat too, this is filtered out now.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed titles not rendering due to parsing errors.

- Adjusted default transition times for better accuracy.

- Ignored `game_info` messages in chat to prevent incorrect display.

- Improved handling of title and action bar components with new parsing logic.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChatProvider.tsx</strong><dd><code>Ignore `game_info` messages in chat</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/react/ChatProvider.tsx

<li>Added logic to ignore <code>game_info</code> messages in chat.<br> <li> Ensured action bar messages are handled by <code>TitleProvider</code>.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/254/files#diff-35736a6f1c0ad8e45df86764d4f53c617ff1c7170795b02a4d398f269f9d7e3a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Title.stories.tsx</strong><dd><code>Update default transition times in stories</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/react/Title.stories.tsx

<li>Updated default transition times for fade-in, stay, and fade-out.<br> <li> Adjusted storybook example to reflect new timing values.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/254/files#diff-c72d0221c8b0087c05ab45731c1c30706b73b586825994a31889c58304286fb1">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Title.tsx</strong><dd><code>Refactor transition timing logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/react/Title.tsx

<li>Replaced default duration with separate fade-in and fade-out defaults.<br> <li> Updated transition logic to use new default timing values.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/254/files#diff-4f9850db93942bf94669128d545ec267ffdda9dc9fcb288e5a0e66167a6efe56">+10/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TitleProvider.tsx</strong><dd><code>Enhance title component parsing and timing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/react/TitleProvider.tsx

<li>Introduced <code>getComponent</code> function for parsing title components.<br> <li> Updated default timing values for title animations.<br> <li> Improved handling of title, subtitle, and action bar packets.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/254/files#diff-6d4edb8637ace068f016517a70c39ef19868a94082a6f82fdc708de02115c9b9">+21/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>