### PR TITLE
fix: skins of NPCs would not get applied properly

### DIFF
--- a/prismarine-viewer/examples/scenes/main.ts
+++ b/prismarine-viewer/examples/scenes/main.ts
@@ -112,7 +112,7 @@ class MainScene extends BasePlaygroundScene {
       this.entityUpdateShared()
       if (!this.params.entity) return
       if (this.params.entity === 'player') {
-        viewer.entities.updatePlayerSkin('id', viewer.entities.entities.id.username, true, true)
+        viewer.entities.updatePlayerSkin('id', viewer.entities.entities.id.username, undefined, true, true)
         viewer.entities.playAnimation('id', 'running')
       }
       // let prev = false

--- a/prismarine-viewer/viewer/lib/entities.ts
+++ b/prismarine-viewer/viewer/lib/entities.ts
@@ -199,6 +199,7 @@ export type SceneEntity = THREE.Object3D & {
     animation?: PlayerAnimation
   }
   username?: string
+  uuid?: string
   additionalCleanup?: () => void
 }
 
@@ -279,18 +280,18 @@ export class Entities extends EventEmitter {
   // fixme workaround
   defaultSteveTexture
 
-  usernamePerSkinUrlsCache = {} as Record<string, { skinUrl?: string, capeUrl?: string }>
+  uuidPerSkinUrlsCache = {} as Record<string, { skinUrl?: string, capeUrl?: string }>
 
   // true means use default skin url
-  updatePlayerSkin (entityId: string | number, username: string | undefined, skinUrl: string | true, capeUrl: string | true | undefined = undefined) {
-    if (username) {
-      if (typeof skinUrl === 'string' || typeof capeUrl === 'string') this.usernamePerSkinUrlsCache[username] = {}
-      if (typeof skinUrl === 'string') this.usernamePerSkinUrlsCache[username].skinUrl = skinUrl
-      if (typeof capeUrl === 'string') this.usernamePerSkinUrlsCache[username].capeUrl = capeUrl
+  updatePlayerSkin (entityId: string | number, username: string | undefined, uuid: string | undefined, skinUrl: string | true, capeUrl: string | true | undefined = undefined) {
+    if (uuid) {
+      if (typeof skinUrl === 'string' || typeof capeUrl === 'string') this.uuidPerSkinUrlsCache[uuid] = {}
+      if (typeof skinUrl === 'string') this.uuidPerSkinUrlsCache[uuid].skinUrl = skinUrl
+      if (typeof capeUrl === 'string') this.uuidPerSkinUrlsCache[uuid].capeUrl = capeUrl
       if (skinUrl === true) {
-        skinUrl = this.usernamePerSkinUrlsCache[username]?.skinUrl ?? skinUrl
+        skinUrl = this.uuidPerSkinUrlsCache[uuid]?.skinUrl ?? skinUrl
       }
-      capeUrl ??= this.usernamePerSkinUrlsCache[username]?.capeUrl
+      capeUrl ??= this.uuidPerSkinUrlsCache[uuid]?.capeUrl
     }
 
     let playerObject = this.getPlayerObject(entityId)
@@ -586,7 +587,7 @@ export class Entities extends EventEmitter {
       this.emit('add', entity)
 
       if (isPlayerModel) {
-        this.updatePlayerSkin(entity.id, '', overrides?.texture || stevePng)
+        this.updatePlayerSkin(entity.id, entity.username, entity.uuid, overrides?.texture || stevePng)
       }
       this.setDebugMode(this.debugMode, group)
       this.setRendering(this.rendering, group)

--- a/prismarine-viewer/viewer/lib/entity/armorModels.json
+++ b/prismarine-viewer/viewer/lib/entity/armorModels.json
@@ -1,4 +1,37 @@
 {
+  "skull": {
+    "bones": [
+      {
+        "name": "head",
+        "pivot": [0, 12, 0],
+        "cubes": [
+          {
+            "origin": [-4, 0, -4],
+            "size": [8, 8, 8],
+            "uv": [0, 0],
+            "inflate": 1
+          }
+        ]
+      },
+      {
+        "name": "overlay",
+        "parent": "head",
+        "pivot": [0, 12, 0],
+        "cubes": [
+          {
+            "origin": [-4, 0, -4],
+            "size": [8, 8, 8],
+            "uv": [32, 0],
+            "inflate": 1.2
+          }
+        ]
+      }
+    ],
+    "visible_bounds_width": 1.5,
+    "visible_bounds_offset": [0, 0.5, 0],
+    "texturewidth": 64,
+    "textureheight": 32
+  },
   "head": {
     "bones": [
       {"name": "armor", "pivot": [0, 12, 0]},
@@ -12,6 +45,19 @@
             "size": [8, 8, 8],
             "uv": [0, 0],
             "inflate": 1
+          }
+        ]
+      },
+      {
+        "name": "overlay",
+        "parent": "head",
+        "pivot": [0, 12, 0],
+        "cubes": [
+          {
+            "origin": [-4, 23, -4],
+            "size": [8, 8, 8],
+            "uv": [32, 0],
+            "inflate": 1.2
           }
         ]
       }

--- a/prismarine-viewer/viewer/lib/mesher/models.ts
+++ b/prismarine-viewer/viewer/lib/mesher/models.ts
@@ -460,6 +460,7 @@ export function getSectionGeometry (sx, sy, sz, world: World) {
     indices: [],
     tiles: {},
     // todo this can be removed here
+    heads: {},
     signs: {},
     // isFull: true,
     highestBlocks: new Map<string, HighestBlockInfo>([]),
@@ -493,6 +494,20 @@ export function getSectionGeometry (sx, sy, sz, world: World) {
           attr.signs[key] = {
             isWall,
             isHanging,
+            rotation: isWall ? facingRotationMap[props.facing] : +props.rotation
+          }
+        } else if (block.name === 'player_head' || block.name === 'player_wall_head') {
+          const key = `${cursor.x},${cursor.y},${cursor.z}`
+          const props: any = block.getProperties()
+          const facingRotationMap = {
+            'north': 0,
+            'south': 2,
+            'west': 3,
+            'east': 1
+          }
+          const isWall = block.name === 'player_wall_head'
+          attr.heads[key] = {
+            isWall,
             rotation: isWall ? facingRotationMap[props.facing] : +props.rotation
           }
         }

--- a/prismarine-viewer/viewer/lib/mesher/shared.ts
+++ b/prismarine-viewer/viewer/lib/mesher/shared.ts
@@ -30,6 +30,7 @@ export type MesherGeometryOutput = {
 
   indices: number[],
   tiles: Record<string, BlockType>,
+  heads: Record<string, any>,
   signs: Record<string, any>,
   // isFull: boolean
   highestBlocks: Map<string, HighestBlockInfo>

--- a/prismarine-viewer/viewer/lib/worldrendererThree.ts
+++ b/prismarine-viewer/viewer/lib/worldrendererThree.ts
@@ -12,6 +12,8 @@ import { disposeObject } from './threeJsUtils'
 import HoldingBlock, { HandItemBlock } from './holdingBlock'
 import { addNewStat } from './ui/newStats'
 import { MesherGeometryOutput } from './mesher/shared'
+import { getMesh } from './entity/EntityMesh'
+import { armorModel } from './entity/armorModels'
 
 export class WorldRendererThree extends WorldRendererCommon {
   interactionLines: null | { blockPos; mesh } = null
@@ -188,12 +190,22 @@ export class WorldRendererThree extends WorldRendererCommon {
     // should not compute it once
     if (Object.keys(data.geometry.signs).length) {
       for (const [posKey, { isWall, isHanging, rotation }] of Object.entries(data.geometry.signs)) {
-        const [x, y, z] = posKey.split(',')
         const signBlockEntity = this.blockEntities[posKey]
         if (!signBlockEntity) continue
+        const [x, y, z] = posKey.split(',')
         const sign = this.renderSign(new Vec3(+x, +y, +z), rotation, isWall, isHanging, nbt.simplify(signBlockEntity))
         if (!sign) continue
         object.add(sign)
+      }
+    }
+    if (Object.keys(data.geometry.heads).length) {
+      for (const [posKey, { isWall, rotation }] of Object.entries(data.geometry.heads)) {
+        const headBlockEntity = this.blockEntities[posKey]
+        if (!headBlockEntity) continue
+        const [x, y, z] = posKey.split(',')
+        const head = this.renderHead(new Vec3(+x, +y, +z), rotation, isWall, nbt.simplify(headBlockEntity))
+        if (!head) continue
+        object.add(head)
       }
     }
     this.sectionObjects[data.key] = object
@@ -243,6 +255,35 @@ export class WorldRendererThree extends WorldRendererCommon {
     if (this.config.displayHand) {
       this.holdingBlock.render(this.camera, this.renderer, viewer.ambientLight, viewer.directionalLight)
       this.holdingBlockLeft.render(this.camera, this.renderer, viewer.ambientLight, viewer.directionalLight)
+    }
+  }
+
+  renderHead (position: Vec3, rotation: number, isWall: boolean, blockEntity) {
+    const textures = blockEntity.SkullOwner?.Properties?.textures[0]
+    if (!textures) return
+
+    try {
+      const textureData = JSON.parse(Buffer.from(textures.Value, 'base64').toString())
+      const skinUrl = textureData.textures?.SKIN?.url
+
+      const mesh = getMesh(this, skinUrl, armorModel.head)
+      const group = new THREE.Group()
+      if (isWall) {
+        mesh.position.set(0, 0.3125, 0.3125)
+      }
+      // move head model down as armor have a different offset than blocks
+      mesh.position.y -= 23 / 16
+      group.add(mesh)
+      group.position.set(position.x + 0.5, position.y + 0.045, position.z + 0.5)
+      group.rotation.set(
+        0,
+        -THREE.MathUtils.degToRad(rotation * (isWall ? 90 : 45 / 2)),
+        0
+      )
+      group.scale.set(0.8, 0.8, 0.8)
+      return group
+    } catch (err) {
+      console.error('Error decoding player texture:', err)
     }
   }
 

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -156,8 +156,12 @@ customEvents.on('gameLoaded', () => {
 
   // Texture override from packet properties
   bot._client.on('player_info', (packet) => {
-    for (const player of packet.data) {
-      const textureProperty = player.properties?.find(prop => prop.name === 'textures')
+    for (const playerEntry of packet.data) {
+      if (!playerEntry.player && !playerEntry.properties) continue
+      let textureProperty = playerEntry.properties?.find(prop => prop?.name === 'textures')
+      if (!textureProperty) {
+        textureProperty = playerEntry.player?.properties?.find(prop => prop?.key === 'textures')
+      }
       if (textureProperty) {
         try {
           const textureData = JSON.parse(Buffer.from(textureProperty.value, 'base64').toString())
@@ -167,13 +171,13 @@ customEvents.on('gameLoaded', () => {
           // Find entity with matching UUID and update skin
           let entityId = ''
           for (const [entId, entity] of Object.entries(bot.entities)) {
-            if (entity.uuid === player.UUID) {
+            if (entity.uuid === playerEntry.uuid) {
               entityId = entId
               break
             }
           }
           // even if not found, still record to cache
-          viewer.entities.updatePlayerSkin(entityId, player.name, skinUrl, capeUrl)
+          viewer.entities.updatePlayerSkin(entityId, playerEntry.player?.name, playerEntry.uuid, skinUrl, capeUrl)
         } catch (err) {
           console.error('Error decoding player texture:', err)
         }

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -115,7 +115,7 @@ customEvents.on('gameLoaded', () => {
       if (viewer.entities.entities[e.id]) {
         if (loadedSkinEntityIds.has(e.id)) return
         loadedSkinEntityIds.add(e.id)
-        viewer.entities.updatePlayerSkin(e.id, e.username, true, true)
+        viewer.entities.updatePlayerSkin(e.id, e.username, e.uuid, true, true)
       }
     }
   }


### PR DESCRIPTION
### **User description**
This fixes that skin data wasn't read from the player info packet properly (at least not in 1.21.4) which is required to have skins working with plugins that add NPCs with fake players like Citizens.

The change also fixes that players/NPCs with the same apparent name would use the same skin as they were cached by username not by UUID.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed NPC skins not applying correctly by using UUID-based caching.

- Updated `updatePlayerSkin` to use UUID instead of username for skin management.

- Improved handling of player texture properties in `player_info` packets.

- Enhanced entity skin update logic to avoid conflicts with duplicate usernames.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.ts</strong><dd><code>Update `updatePlayerSkin` call to use UUID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

prismarine-viewer/examples/scenes/main.ts

<li>Updated <code>updatePlayerSkin</code> call to include UUID parameter.<br> <li> Adjusted function call to align with new UUID-based caching.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/265/files#diff-62546698608e4d7b6842f809bea25b242656a334f6e79b12bb9db7ab2ae7a84a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>entities.ts</strong><dd><code>Refactor skin caching and updates to use UUID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

prismarine-viewer/viewer/lib/entities.ts

<li>Replaced username-based skin caching with UUID-based caching.<br> <li> Modified <code>updatePlayerSkin</code> to accept UUID for skin updates.<br> <li> Adjusted logic to fetch skins using UUID instead of username.<br> <li> Updated entity creation to use UUID for skin updates.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/265/files#diff-ac90a590e52054eac7ddf6f1a261260cece5fe3ac3f830e07f37cee96f574d06">+10/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entities.ts</strong><dd><code>Enhance `player_info` packet handling and skin updates</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/entities.ts

<li>Improved parsing of <code>player_info</code> packets for texture properties.<br> <li> Added fallback logic for missing texture properties in packets.<br> <li> Updated skin update logic to use UUID and handle missing data <br>gracefully.<br> <li> Fixed entity matching by UUID for skin updates.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/265/files#diff-fbd8e1205a6f8147097a9d9aab61b2a3ce28692d3e8bd2831b17022520fd7f81">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>