### PR TITLE
fix: resource pack armor textures and leather armor color bleed

### DIFF
--- a/renderer/viewer/lib/entities.ts
+++ b/renderer/viewer/lib/entities.ts
@@ -991,6 +991,8 @@ function addArmorModel (entityMesh: THREE.Object3D, slotType: string, item: Item
       material.color.setHex(0xB5_6D_51) // default brown color
     }
     addArmorModel(entityMesh, slotType, item, layer, true)
+  } else {
+    material.color.setHex(0xFF_FF_FF)
   }
   const group = new THREE.Object3D()
   group.name = `armor_${slotType}${overlay ? '_overlay' : ''}`

--- a/renderer/viewer/lib/entities.ts
+++ b/renderer/viewer/lib/entities.ts
@@ -20,7 +20,7 @@ import * as Entity from './entity/EntityMesh'
 import { getMesh } from './entity/EntityMesh'
 import { WalkingGeneralSwing } from './entity/animations'
 import { disposeObject } from './threeJsUtils'
-import { armorModels } from './entity/objModels'
+import { armorModel, armorTextures } from './entity/armorModels'
 import { Viewer } from './viewer'
 import { getBlockMeshFromModel } from './holdingBlock'
 const { loadTexture } = globalThis.isElectron ? require('./utils.electron.js') : require('./utils')
@@ -950,11 +950,11 @@ function addArmorModel (entityMesh: THREE.Object3D, slotType: string, item: Item
   }
   const armorMaterial = itemParts[0]
   if (!texturePath) {
-    // TODO: Support resource pack
     // TODO: Support mirroring on certain parts of the model
-    texturePath = armorModels[`${armorMaterial}Layer${layer}${overlay ? 'Overlay' : ''}`]
+    const armorTextureName = `${armorMaterial}_layer_${layer}${overlay ? '_overlay' : ''}`
+    texturePath = viewer.world.customTextures.armor?.textures[armorTextureName]?.src ?? armorTextures[armorTextureName]
   }
-  if (!texturePath || !armorModels.armorModel[slotType]) {
+  if (!texturePath || !armorModel[slotType]) {
     removeArmorModel(entityMesh, slotType)
     return
   }
@@ -973,7 +973,7 @@ function addArmorModel (entityMesh: THREE.Object3D, slotType: string, item: Item
       material.map = texture
     })
   } else {
-    mesh = getMesh(viewer.world, texturePath, armorModels.armorModel[slotType])
+    mesh = getMesh(viewer.world, texturePath, armorModel[slotType])
     mesh.name = meshName
     material = mesh.material
     if (!isPlayerHead) {

--- a/renderer/viewer/lib/entity/armorModels.ts
+++ b/renderer/viewer/lib/entity/armorModels.ts
@@ -1,36 +1,35 @@
-/*
- * prismarine-web-client - prismarine-web-client
- * Copyright (C) 2024 Max Lee aka Phoenix616 (mail@moep.tv)
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
-
-// TODO: replace with load from resource pack
-export { default as chainmailLayer1 } from 'mc-assets/dist/other-textures/latest/models/armor/chainmail_layer_1.png'
-export { default as chainmailLayer2 } from 'mc-assets/dist/other-textures/latest/models/armor/chainmail_layer_2.png'
-export { default as diamondLayer1 } from 'mc-assets/dist/other-textures/latest/models/armor/diamond_layer_1.png'
-export { default as diamondLayer2 } from 'mc-assets/dist/other-textures/latest/models/armor/diamond_layer_2.png'
-export { default as goldenLayer1 } from 'mc-assets/dist/other-textures/latest/models/armor/gold_layer_1.png'
-export { default as goldenLayer2 } from 'mc-assets/dist/other-textures/latest/models/armor/gold_layer_2.png'
-export { default as ironLayer1 } from 'mc-assets/dist/other-textures/latest/models/armor/iron_layer_1.png'
-export { default as ironLayer2 } from 'mc-assets/dist/other-textures/latest/models/armor/iron_layer_2.png'
-export { default as leatherLayer1 } from 'mc-assets/dist/other-textures/latest/models/armor/leather_layer_1.png'
-export { default as leatherLayer1Overlay } from 'mc-assets/dist/other-textures/latest/models/armor/leather_layer_1_overlay.png'
-export { default as leatherLayer2 } from 'mc-assets/dist/other-textures/latest/models/armor/leather_layer_2.png'
-export { default as leatherLayer2Overlay } from 'mc-assets/dist/other-textures/latest/models/armor/leather_layer_2_overlay.png'
-export { default as netheriteLayer1 } from 'mc-assets/dist/other-textures/latest/models/armor/netherite_layer_1.png'
-export { default as netheriteLayer2 } from 'mc-assets/dist/other-textures/latest/models/armor/netherite_layer_2.png'
-export { default as turtleLayer1 } from 'mc-assets/dist/other-textures/latest/models/armor/turtle_layer_1.png'
+import { default as chainmailLayer1 } from 'mc-assets/dist/other-textures/latest/models/armor/chainmail_layer_1.png'
+import { default as chainmailLayer2 } from 'mc-assets/dist/other-textures/latest/models/armor/chainmail_layer_2.png'
+import { default as diamondLayer1 } from 'mc-assets/dist/other-textures/latest/models/armor/diamond_layer_1.png'
+import { default as diamondLayer2 } from 'mc-assets/dist/other-textures/latest/models/armor/diamond_layer_2.png'
+import { default as goldenLayer1 } from 'mc-assets/dist/other-textures/latest/models/armor/gold_layer_1.png'
+import { default as goldenLayer2 } from 'mc-assets/dist/other-textures/latest/models/armor/gold_layer_2.png'
+import { default as ironLayer1 } from 'mc-assets/dist/other-textures/latest/models/armor/iron_layer_1.png'
+import { default as ironLayer2 } from 'mc-assets/dist/other-textures/latest/models/armor/iron_layer_2.png'
+import { default as leatherLayer1 } from 'mc-assets/dist/other-textures/latest/models/armor/leather_layer_1.png'
+import { default as leatherLayer1Overlay } from 'mc-assets/dist/other-textures/latest/models/armor/leather_layer_1_overlay.png'
+import { default as leatherLayer2 } from 'mc-assets/dist/other-textures/latest/models/armor/leather_layer_2.png'
+import { default as leatherLayer2Overlay } from 'mc-assets/dist/other-textures/latest/models/armor/leather_layer_2_overlay.png'
+import { default as netheriteLayer1 } from 'mc-assets/dist/other-textures/latest/models/armor/netherite_layer_1.png'
+import { default as netheriteLayer2 } from 'mc-assets/dist/other-textures/latest/models/armor/netherite_layer_2.png'
+import { default as turtleLayer1 } from 'mc-assets/dist/other-textures/latest/models/armor/turtle_layer_1.png'
 
 export { default as armorModel } from './armorModels.json'
+
+export const armorTextures = {
+  'leather_layer_1': leatherLayer1,
+  'leather_layer_1_overlay': leatherLayer1Overlay,
+  'leather_layer_2': leatherLayer2,
+  'leather_layer_2_overlay': leatherLayer2Overlay,
+  'chainmail_layer_1': chainmailLayer1,
+  'chainmail_layer_2': chainmailLayer2,
+  'iron_layer_1': ironLayer1,
+  'iron_layer_2': ironLayer2,
+  'diamond_layer_1': diamondLayer1,
+  'diamond_layer_2': diamondLayer2,
+  'golden_layer_1': goldenLayer1,
+  'golden_layer_2': goldenLayer2,
+  'netherite_layer_1': netheriteLayer1,
+  'netherite_layer_2': netheriteLayer2,
+  'turtle_layer_1': turtleLayer1
+}

--- a/renderer/viewer/lib/entity/objModels.js
+++ b/renderer/viewer/lib/entity/objModels.js
@@ -1,2 +1,1 @@
 export * as externalModels from './exportedModels'
-export * as armorModels from './armorModels'

--- a/renderer/viewer/lib/worldrendererCommon.ts
+++ b/renderer/viewer/lib/worldrendererCommon.ts
@@ -124,6 +124,7 @@ export abstract class WorldRendererCommon<WorkerSend = any, WorkerReceive = any>
   customTextures: {
     items?: CustomTexturesData
     blocks?: CustomTexturesData
+    armor?: CustomTexturesData
   } = {}
   workersProcessAverageTime = 0
   workersProcessAverageTimeCount = 0

--- a/src/resourcePack.ts
+++ b/src/resourcePack.ts
@@ -4,6 +4,7 @@ import fs from 'fs'
 import JSZip from 'jszip'
 import { proxy, subscribe } from 'valtio'
 import { WorldRendererThree } from 'renderer/viewer/lib/worldrendererThree'
+import { armorTextures } from 'renderer/viewer/lib/entity/armorModels'
 import { collectFilesToCopy, copyFilesAsyncWithProgress, mkdirRecursive, removeFileRecursiveAsync } from './browserfs'
 import { setLoadingScreenStatus } from './appStatus'
 import { showNotification } from './react/NotificationProvider'
@@ -203,7 +204,7 @@ const getFilesMapFromDir = async (dir: string) => {
   return files
 }
 
-export const getResourcepackTiles = async (type: 'blocks' | 'items', existingTextures: string[]) => {
+export const getResourcepackTiles = async (type: 'blocks' | 'items' | 'armor', existingTextures: string[]) => {
   const basePath = await getActiveResourcepackBasePath()
   if (!basePath) return
   let firstTextureSize: number | undefined
@@ -212,11 +213,25 @@ export const getResourcepackTiles = async (type: 'blocks' | 'items', existingTex
     setLoadingScreenStatus(`Generating atlas texture for ${type}`)
   }
   const textures = {} as Record<string, HTMLImageElement>
+  let path
+  switch (type) {
+    case 'blocks':
+      path = 'block'
+      break
+    case 'items':
+      path = 'item'
+      break
+    case 'armor':
+      path = 'models/armor'
+      break
+    default:
+      throw new Error('Invalid type')
+  }
   for (const namespace of namespaces) {
     const texturesCommonBasePath = `${basePath}/assets/${namespace}/textures`
     const isMinecraftNamespace = namespace === 'minecraft'
-    let texturesBasePath = `${texturesCommonBasePath}/${type === 'blocks' ? 'block' : 'item'}`
-    const texturesBasePathAlt = `${texturesCommonBasePath}/${type === 'blocks' ? 'blocks' : 'items'}`
+    let texturesBasePath = `${texturesCommonBasePath}/${path}`
+    const texturesBasePathAlt = `${texturesCommonBasePath}/${path}s`
     if (!(await existsAsync(texturesBasePath))) {
       if (await existsAsync(texturesBasePathAlt)) {
         texturesBasePath = texturesBasePathAlt
@@ -465,9 +480,11 @@ const repeatArr = (arr, i) => Array.from({ length: i }, () => arr)
 const updateTextures = async () => {
   const origBlocksFiles = Object.keys(viewer.world.sourceData.blocksAtlases.latest.textures)
   const origItemsFiles = Object.keys(viewer.world.sourceData.itemsAtlases.latest.textures)
+  const origArmorFiles = Object.keys(armorTextures)
   const { usedTextures: extraBlockTextures = new Set<string>() } = await prepareBlockstatesAndModels() ?? {}
   const blocksData = await getResourcepackTiles('blocks', [...origBlocksFiles, ...extraBlockTextures])
   const itemsData = await getResourcepackTiles('items', origItemsFiles)
+  const armorData = await getResourcepackTiles('armor', origArmorFiles)
   await updateAllReplacableTextures()
   viewer.world.customTextures = {}
   if (blocksData) {
@@ -480,6 +497,12 @@ const updateTextures = async () => {
     viewer.world.customTextures.items = {
       tileSize: itemsData.firstTextureSize,
       textures: itemsData.textures
+    }
+  }
+  if (armorData) {
+    viewer.world.customTextures.armor = {
+      tileSize: armorData.firstTextureSize,
+      textures: armorData.textures
     }
   }
   if (viewer.world.active) {


### PR DESCRIPTION
### **User description**
This fixes that armor textures would not get loaded from a resource pack as well as that the color of the leather armor would bleed to other, non-colored armor pieces when changing leather to different armor directly.

Also remove wrong copyright notice which seems to have been added on accident by my IDE when I added the armor support 🙈 Code is of course still under the project's MIT license.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed armor textures not loading from resource packs.

- Resolved leather armor color bleeding to other armors.

- Added support for custom armor textures from resource packs.

- Removed incorrect copyright notice in `armorModels.ts`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entities.ts</strong><dd><code>Enhance armor texture handling and fix color bleeding</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

renderer/viewer/lib/entities.ts

<li>Updated armor texture loading logic to support resource packs.<br> <li> Fixed leather armor color bleeding issue.<br> <li> Adjusted material color handling for default and custom textures.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/274/files#diff-9e54e3431afdfce03b1a81e39376404cd5d0b7dc6af604051070badf5e18253d">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>armorModels.ts</strong><dd><code>Add armor texture mapping and fix copyright</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

renderer/viewer/lib/entity/armorModels.ts

<li>Removed incorrect copyright notice.<br> <li> Added <code>armorTextures</code> object for texture mapping.<br> <li> Simplified imports for armor texture files.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/274/files#diff-ab1ac35c2bc53c4b74b9bffdf04bccaa20d41d1b0d40115edda883ccd1d93035">+33/-34</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>worldrendererCommon.ts</strong><dd><code>Support custom armor textures in renderer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

renderer/viewer/lib/worldrendererCommon.ts

- Added support for custom armor textures in `customTextures`.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/274/files#diff-550c4710126f42446d56d2e960abe863983ee8a84e9ff403d6a3e2a3f8dece83">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>resourcePack.ts</strong><dd><code>Add resource pack support for armor textures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/resourcePack.ts

<li>Extended <code>getResourcepackTiles</code> to handle armor textures.<br> <li> Integrated armor texture updates in <code>updateTextures</code>.<br> <li> Added logic for loading custom armor textures from resource packs.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/274/files#diff-3b0c9127d897aefc0afea8e44fcec7d2d00d281024cb8c90c8c969deff017be7">+26/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>objModels.js</strong><dd><code>Cleanup unused armorModels export</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

renderer/viewer/lib/entity/objModels.js

- Removed unused `armorModels` export.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/274/files#diff-4627096f32c7ecd11f4fa5de08ff1e8ebaf5c9860bbdb0da68a921f9037779f6">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>