### PR TITLE
feat: option to disable ears on all skins

### DIFF
--- a/renderer/viewer/lib/entities.ts
+++ b/renderer/viewer/lib/entities.ts
@@ -350,12 +350,14 @@ export class Entities extends EventEmitter {
       playerObject.skin.map = skinTexture
       playerObject.skin.modelType = inferModelType(skinTexture.image)
 
-      const earsCanvas = document.createElement('canvas')
-      loadEarsToCanvasFromSkin(earsCanvas, image)
-      if (isCanvasBlank(earsCanvas)) {
-        playerObject.ears.map = null
-        playerObject.ears.visible = false
-      } else {
+      let renderEars = this.viewer.world.config.renderEars || username === 'deadmau5'
+      let earsCanvas
+      if (renderEars) {
+        earsCanvas = document.createElement('canvas')
+        loadEarsToCanvasFromSkin(earsCanvas, image)
+        renderEars = !isCanvasBlank(earsCanvas)
+      }
+      if (renderEars) {
         const earsTexture = new THREE.CanvasTexture(earsCanvas)
         earsTexture.magFilter = THREE.NearestFilter
         earsTexture.minFilter = THREE.NearestFilter
@@ -363,6 +365,9 @@ export class Entities extends EventEmitter {
         //@ts-expect-error
         playerObject.ears.map = earsTexture
         playerObject.ears.visible = true
+      } else {
+        playerObject.ears.map = null
+        playerObject.ears.visible = false
       }
       this.onSkinUpdate?.()
       if (capeUrl) {

--- a/renderer/viewer/lib/worldrendererCommon.ts
+++ b/renderer/viewer/lib/worldrendererCommon.ts
@@ -33,6 +33,7 @@ export const defaultWorldRendererConfig = {
   showChunkBorders: false,
   numWorkers: 4,
   isPlayground: false,
+  renderEars: true,
   // game renderer setting actually
   displayHand: false
 }

--- a/src/optionsGuiScheme.tsx
+++ b/src/optionsGuiScheme.tsx
@@ -92,6 +92,9 @@ export const guiOptionsScheme: {
         tooltip: 'Additional distance to keep the chunks loading before unloading them by marking them as too far',
       },
       handDisplay: {},
+      renderEars: {
+        tooltip: 'Support rendering Deadmau5 ears for all players if their skin contains textures for it',
+      },
       renderDebug: {
         values: [
           'advanced',

--- a/src/optionsGuiScheme.tsx
+++ b/src/optionsGuiScheme.tsx
@@ -93,7 +93,7 @@ export const guiOptionsScheme: {
       },
       handDisplay: {},
       renderEars: {
-        tooltip: 'Support rendering Deadmau5 ears for all players if their skin contains textures for it',
+        tooltip: 'Enable rendering Deadmau5 ears for all players if their skin contains textures for it',
       },
       renderDebug: {
         values: [

--- a/src/optionsStorage.ts
+++ b/src/optionsStorage.ts
@@ -46,6 +46,7 @@ const defaultOptions = {
   unimplementedContainers: false,
   dayCycleAndLighting: true,
   loadPlayerSkins: true,
+  renderEars: true,
   lowMemoryMode: false,
   starfieldRendering: true,
   enabledResourcepack: null as string | null,

--- a/src/watchOptions.ts
+++ b/src/watchOptions.ts
@@ -96,6 +96,7 @@ export const watchOptionsAfterWorldViewInit = () => {
   watchValue(options, o => {
     if (!worldView) return
     worldView.keepChunksDistance = o.keepChunksDistance
+    viewer.world.config.renderEars = o.renderEars
     viewer.world.config.displayHand = o.handDisplay
   })
 }


### PR DESCRIPTION
### **User description**
This adds an option to toggle whether or not the Deadmau5 ears are rendered for skins. Someone might want to toggle them off if skins include a full background there or information for some other mod. If toggled off the Vanilla logic of checking for Deadmau5's username is used and only their skin renders ears.


___

### **PR Type**
Enhancement


___

### **Description**
- Added a configurable option to toggle Deadmau5 ears rendering.

- Updated logic to conditionally render ears based on configuration.

- Integrated the new `renderEars` option into the GUI and options storage.

- Adjusted default settings and watchers to support the new feature.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entities.ts</strong><dd><code>Conditional rendering of Deadmau5 ears based on configuration</code></dd></summary>
<hr>

renderer/viewer/lib/entities.ts

<li>Added logic to conditionally render Deadmau5 ears based on <br>configuration.<br> <li> Ensured ears rendering is disabled if the canvas is blank.<br> <li> Refactored existing ears rendering logic to support new option.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/275/files#diff-9e54e3431afdfce03b1a81e39376404cd5d0b7dc6af604051070badf5e18253d">+11/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>optionsGuiScheme.tsx</strong><dd><code>Integrated `renderEars` option into GUI scheme</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/optionsGuiScheme.tsx

<li>Added <code>renderEars</code> option to GUI scheme.<br> <li> Provided tooltip description for <code>renderEars</code> option.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/275/files#diff-fb8f8e0db6f3566f74765e85fe9ab585d0b20cd42c71dbbe9bd628700079c099">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>optionsStorage.ts</strong><dd><code>Added `renderEars` to options storage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/optionsStorage.ts

<li>Added <code>renderEars</code> to default options storage.<br> <li> Ensured <code>renderEars</code> is included in the options structure.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/275/files#diff-d4948a47c8d2f63541b2d4fe04729fde3fb837668f72ae1eceb9b9ab8ba626fb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>watchOptions.ts</strong><dd><code>Updated watcher to handle `renderEars` configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/watchOptions.ts

<li>Updated watcher to apply <code>renderEars</code> configuration dynamically.<br> <li> Ensured <code>renderEars</code> is synchronized with viewer configuration.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/275/files#diff-ef97dcd164e5692517b48e1f63a9aa76437dcf7dfa4f483fbcb2cea0ca30d5ca">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>worldrendererCommon.ts</strong><dd><code>Added `renderEars` to default configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

renderer/viewer/lib/worldrendererCommon.ts

<li>Introduced <code>renderEars</code> as a default configuration option.<br> <li> Set default value for <code>renderEars</code> to <code>true</code>.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/275/files#diff-550c4710126f42446d56d2e960abe863983ee8a84e9ff403d6a3e2a3f8dece83">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>