### PR TITLE
fix: autoConnect parameter wouldn't do anything

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -152,6 +152,7 @@ Server specific:
 - `?proxy=<proxy_address>` - Set the proxy server address to use for  the server
 - `?username=<username>` - Set the username for the server
 - `?lockConnect=true` - Only works then `ip` parameter is set. Disables cancel/save buttons and all inputs in the connect screen already set as parameters. Useful for integrates iframes.
+- `?autoConnect=true` - Only works then `ip` and `version` parameters are set and `allowAutoConnect` is `true` in config.json! Directly connects to the specified server. Useful for integrates iframes.
 - `?serversList=<list_or_url>` - `<list_or_url>` can be a list of servers in the format `ip:version,ip` or a url to a json file with the same format (array) or a txt file with line-delimited list of server IPs.
 
 Single player specific:

--- a/src/react/AddServerOrConnect.tsx
+++ b/src/react/AddServerOrConnect.tsx
@@ -42,6 +42,7 @@ export default ({ onBack, onConfirm, title = 'Add a Server', initialData, parseQ
   const qsParamProxy = parseQs ? appQueryParams.proxy : undefined
   const qsParamUsername = parseQs ? appQueryParams.username : undefined
   const qsParamLockConnect = parseQs ? appQueryParams.lockConnect : undefined
+  const qsParamAutoConnect = parseQs ? appQueryParams.autoConnect : undefined
 
   const parsedQsIp = parseServerAddress(qsParamIp)
   const parsedInitialIp = parseServerAddress(initialData?.ip)
@@ -121,7 +122,7 @@ export default ({ onBack, onConfirm, title = 'Add a Server', initialData, parseQ
   }
 
   useEffect(() => {
-    if (qsParamIp && qsParamVersion && allowAutoConnect) {
+    if (qsParamAutoConnect && qsParamIp && qsParamVersion && allowAutoConnect) {
       onQsConnect?.(commonUseOptions)
     }
   }, [])


### PR DESCRIPTION
### **User description**
The change to an object for the parameters seems to have broken the `autoConnect` URL parameter: https://github.com/zardoy/minecraft-web-client/commit/d4e93d4d39dd9c2652bf5ad1536075721572db3f#diff-9dbc0f17c726d8e350834102ba9f20348c4551e350efb06b81560a70c051bd73L123-R123

This re-adds it and also documents how it works.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fixed the `autoConnect` parameter functionality in the application.

- Added `autoConnect` parameter handling in `AddServerOrConnect.tsx`.

- Documented the `autoConnect` parameter usage in `README.MD`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AddServerOrConnect.tsx</strong><dd><code>Add and handle `autoConnect` query parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/react/AddServerOrConnect.tsx

<li>Added handling for <code>autoConnect</code> query parameter.<br> <li> Updated logic to include <code>autoConnect</code> in conditional checks.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/276/files#diff-9dbc0f17c726d8e350834102ba9f20348c4551e350efb06b81560a70c051bd73">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.MD</strong><dd><code>Document `autoConnect` parameter usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.MD

<li>Documented the <code>autoConnect</code> query parameter.<br> <li> Explained its usage and conditions for functionality.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/276/files#diff-01e6d9ffed056a02cae8d8a0ec5d476a64d017bf85c0d5a94bb23ca21f33f5aa">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>