### PR TITLE
fix: maps on invisible Item Frames would have gap

### DIFF
--- a/renderer/viewer/lib/entities.ts
+++ b/renderer/viewer/lib/entities.ts
@@ -897,7 +897,7 @@ export class Entities extends EventEmitter {
 
     mapMesh.rotation.set(0, Math.PI, 0)
     entityMesh.add(mapMesh)
-    let isInvisible = false
+    let isInvisible = true
     entityMesh.traverseVisible(c => {
       if (c.name === 'geometry_frame') {
         isInvisible = false


### PR DESCRIPTION
### **User description**
This fixes that maps on invisible Item Frames would float above the blocks with a gap in between instead of being flush with the wall like it was intended.

Not sure how I missed that before, that's an obvious error in the code.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed alignment issue for maps on invisible item frames.

- Ensured maps are flush with walls as intended.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entities.ts</strong><dd><code>Fix map alignment on invisible item frames</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

renderer/viewer/lib/entities.ts

<li>Changed default value of <code>isInvisible</code> to <code>true</code>.<br> <li> Corrected logic for handling invisible item frames.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/281/files#diff-9e54e3431afdfce03b1a81e39376404cd5d0b7dc6af604051070badf5e18253d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>