### PR TITLE
fix: baby mobs are not rendered smaller

### DIFF
--- a/renderer/viewer/lib/entities.ts
+++ b/renderer/viewer/lib/entities.ts
@@ -714,7 +714,13 @@ export class Entities extends EventEmitter {
       }
     }
     // ---
-    // not player
+    // set baby size
+    if (meta.baby) {
+      e.scale.set(0.5, 0.5, 0.5)
+    } else {
+      e.scale.set(1, 1, 1)
+    }
+    // entity specific meta
     const textDisplayMeta = getSpecificEntityMetadata('text_display', entity)
     const displayTextRaw = textDisplayMeta?.text || meta.custom_name_visible && meta.custom_name
     const displayText = this.parseEntityLabel(displayTextRaw)


### PR DESCRIPTION
### **User description**
This fixes that baby versions of mobs would have the same size as normal ones.

This does not implement the different scaling of the head of those mobs due to no unified entity model format nor the concept of modifying individual body parts of the models existing. This would ideally need a rework of the model system to be easily possible. For now just rendering them smaller at least gives some indication of a difference even though it's not exact to the game.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes rendering of baby mobs to appear smaller.

- Adds scaling logic for baby and normal entities.

- Ensures baby mobs are visually distinct from adults.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entities.ts</strong><dd><code>Add scaling logic for baby and normal entities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

renderer/viewer/lib/entities.ts

<li>Added scaling logic to render baby mobs smaller.<br> <li> Ensures baby mobs scale to 0.5x size.<br> <li> Resets scale to 1x for non-baby entities.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/283/files#diff-9e54e3431afdfce03b1a81e39376404cd5d0b7dc6af604051070badf5e18253d">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>