### PR TITLE
feat: add config option for pause screen links

### DIFF
--- a/config.json
+++ b/config.json
@@ -17,5 +17,15 @@
       "version": "1.20.3",
       "description": "Very nice a polite server. Must try for everyone!"
     }
+  ],
+  "pauseLinks": [
+    [
+      {
+        "type": "github"
+      },
+      {
+        "type": "discord"
+      }
+    ]
   ]
 }

--- a/src/globalState.ts
+++ b/src/globalState.ts
@@ -122,6 +122,7 @@ export type AppConfig = {
 
   defaultSettings?: Record<string, any>
   allowAutoConnect?: boolean
+  pauseLinks?: Array<Array<Record<string, any>>>
 }
 
 export const miscUiState = proxy({

--- a/src/react/DiscordButton.tsx
+++ b/src/react/DiscordButton.tsx
@@ -4,7 +4,7 @@ import { CSSProperties, useState } from 'react'
 import Button from './Button'
 import PixelartIcon, { pixelartIcons } from './PixelartIcon'
 
-export const DiscordButton = () => {
+export const DiscordButton = ({ text, style }: { text?: string, style?: Record<string, any> }) => {
   const links: DropdownButtonItem[] = [
     {
       text: 'Support Official Server (mcraft.fun)',
@@ -16,7 +16,7 @@ export const DiscordButton = () => {
     }
   ]
 
-  return <DropdownButton text="Discord" links={links} />
+  return <DropdownButton text={text ?? 'Discord'} style={style} links={links} />
 }
 
 export type DropdownButtonItem = {
@@ -24,7 +24,7 @@ export type DropdownButtonItem = {
   clickHandler: () => void
 }
 
-export const DropdownButton = ({ text, links }: { text: string, links: DropdownButtonItem[] }) => {
+export const DropdownButton = ({ text, style, links }: { text: string, style?: Record<string, any>, links: DropdownButtonItem[] }) => {
   const [isOpen, setIsOpen] = useState(false)
   const { refs, floatingStyles } = useFloating({
     open: isOpen,
@@ -50,7 +50,7 @@ export const DropdownButton = ({ text, links }: { text: string, links: DropdownB
 
   return <>
     <Button
-      style={{ position: 'relative', width: '98px' }}
+      style={style ?? { position: 'relative', width: '98px' }}
       rootRef={refs.setReference}
       onClick={() => {
         setIsOpen(!isOpen)

--- a/src/react/PauseScreen.tsx
+++ b/src/react/PauseScreen.tsx
@@ -18,7 +18,7 @@ import {
 } from '../globalState'
 import { fsState } from '../loadSave'
 import { disconnect } from '../flyingSquidUtils'
-import { pointerLock } from '../utils'
+import { openGithub, pointerLock } from '../utils'
 import { setLoadingScreenStatus } from '../appStatus'
 import { closeWan, openToWanAndCopyJoinLink, getJoinLink } from '../localServerMultiplayer'
 import { collectFilesToCopy, fileExistsAsyncOptimized, mkdirRecursive, uniqueFileNameFromWorldName } from '../browserfs'
@@ -222,6 +222,26 @@ export default () => {
   }
 
   if (!isModalActive) return null
+
+  const pauseLinks: any[] = []
+  const pauseLinksConfig = miscUiState.appConfig?.pauseLinks
+  if (pauseLinksConfig) {
+    for (const row of pauseLinksConfig) {
+      const rowButtons: any[] = []
+      for (const button of row) {
+        const style = { width: (204 / row.length - (row.length > 1 ? 4 : 0)) + 'px' }
+        if (button.type === 'discord') {
+          rowButtons.push(<DiscordButton style={style} text={button.text}/>)
+        } else if (button.type === 'github') {
+          rowButtons.push(<Button className="button" style={style} onClick={() => openGithub()}>{button.text ?? 'GitHub'}</Button>)
+        } else if (button.type === 'url' && button.text) {
+          rowButtons.push(<Button className="button" style={style} onClick={() => openURL(button.url)}>{button.text}</Button>)
+        }
+      }
+      pauseLinks.push(<div className={styles.row}>{rowButtons}</div>)
+    }
+  }
+
   return <Screen title='Game Menu'>
     <Button
       icon="pixelarticons:folder"
@@ -235,10 +255,7 @@ export default () => {
     </ErrorBoundary>
     <div className={styles.pause_container}>
       <Button className="button" style={{ width: '204px' }} onClick={onReturnPress}>Back to Game</Button>
-      <div className={styles.row}>
-        <Button className="button" style={{ width: '98px' }} onClick={() => openURL(process.env.GITHUB_URL!)}>GitHub</Button>
-        <DiscordButton />
-      </div>
+      {pauseLinks}
       <Button className="button" style={{ width: '204px' }} onClick={() => openOptionsMenu('main')}>Options</Button>
       {singleplayer ? (
         <div className={styles.row}>


### PR DESCRIPTION
### **User description**
This adds the ability to configure the links shown in the pause screen via the `config.json`. The github and Discord buttons are hardcoded for now (as they include custom logic and the link from the environment variable) but the ability to specify custom URL buttons was included too:

```json
{
  "type": "url",
  "text": "Button Text",
  "url": "https://example.com"
}
``` 

(Multiple lines of buttons are supported too as every line is an array of button records)


___

### **PR Type**
Enhancement


___

### **Description**
- Added configurable pause screen links via `config.json`.

- Enhanced `DiscordButton` and `DropdownButton` components with style and text props.

- Updated `PauseScreen` to dynamically render buttons based on configuration.

- Introduced `pauseLinks` configuration in `config.json` for custom button rows.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>globalState.ts</strong><dd><code>Added `pauseLinks` configuration to global state.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/globalState.ts

- Added `pauseLinks` property to `AppConfig` type.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/288/files#diff-953146e6986dc0254e6cc121a6135a9a2754ab6b761d1af17dd18b27fd4593f4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DiscordButton.tsx</strong><dd><code>Enhanced `DiscordButton` and `DropdownButton` components.</code></dd></summary>
<hr>

src/react/DiscordButton.tsx

<li>Updated <code>DiscordButton</code> to accept <code>text</code> and <code>style</code> props.<br> <li> Updated <code>DropdownButton</code> to accept optional <code>style</code> prop.<br> <li> Adjusted button styling logic for flexibility.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/288/files#diff-3fcffd1e6bb3856dcf4c63bed4a83e6bbb3b8094d377d0b230ee968d6957d936">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PauseScreen.tsx</strong><dd><code>Updated `PauseScreen` to support configurable buttons.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/react/PauseScreen.tsx

<li>Added dynamic rendering of pause screen buttons based on <br>configuration.<br> <li> Integrated <code>DiscordButton</code> and GitHub button with configurable styles.<br> <li> Replaced hardcoded buttons with dynamic <code>pauseLinks</code> rendering.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/288/files#diff-99a6412a94e0c80157501dcaf252db4491920e1bfa0fae935efd3cb2debea1c6">+22/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.json</strong><dd><code>Introduced `pauseLinks` configuration in `config.json`.</code>&nbsp; &nbsp; </dd></summary>
<hr>

config.json

<li>Added <code>pauseLinks</code> configuration for customizable button rows.<br> <li> Included examples for GitHub and Discord buttons.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/288/files#diff-587cb980af76fdc7e52369fd0b9d926dff266976b6f8ac631e358fecc49ff8cf">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - **Dynamic Pause Links:** The pause screen now displays configurable action buttons for GitHub, Discord, and external URLs based on updated settings.
  - **Enhanced Customization:** Key buttons offer customizable text and styling, providing a more personalized and flexible user interface experience during pause interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->