### PR TITLE
Fixed block interaction logic for adventure mode!

### DIFF
--- a/src/worldInteractions.ts
+++ b/src/worldInteractions.ts
@@ -279,7 +279,9 @@ class WorldInteraction {
     const { cursorBlock } = this
 
     let cursorBlockDiggable = cursorBlock
-    if (cursorBlock && (!bot.canDigBlock(cursorBlock) || inAdventure) && bot.game.gameMode !== 'creative') cursorBlockDiggable = null
+    if (!cursorBlock) cursorBlockDiggable = null
+    else if (inAdventure) cursorBlockDiggable = null
+    else if (!bot.canDigBlock(cursorBlock) && bot.game.gameMode != 'creative') cursorBlockDiggable = null
 
     const cursorChanged = cursorBlock && viewer.world.cursorBlock ? !viewer.world.cursorBlock.equals(cursorBlock.position) : viewer.world.cursorBlock !== cursorBlock
 
@@ -318,7 +320,7 @@ class WorldInteraction {
         }
       }
       // todo placing with offhand
-      if (cursorBlock && !activate && !stop) {
+      if (!inAdventure && cursorBlock && !activate && !stop) {
         const vecArray = [new Vec3(0, -1, 0), new Vec3(0, 1, 0), new Vec3(0, 0, -1), new Vec3(0, 0, 1), new Vec3(-1, 0, 0), new Vec3(1, 0, 0)]
         //@ts-expect-error
         const delta = cursorBlock.intersect.minus(cursorBlock.position)


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed block interaction logic for adventure mode.

- Adjusted conditions for `cursorBlockDiggable` assignment.

- Prevented block placement in adventure mode.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>worldInteractions.ts</strong><dd><code>Refine block interaction and placement logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/worldInteractions.ts

<li>Refined logic for <code>cursorBlockDiggable</code> assignment.<br> <li> Added checks to prevent block placement in adventure mode.<br> <li> Adjusted conditions for block interaction and activation.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/289/files#diff-52c2d8c24ce8b36d3ec50aa79533b2105a9207d817df2c5742d5d0e6573018cc">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refined block interaction behavior so that actions like digging and placing respond correctly based on the player's mode and block state, ensuring more consistent gameplay in modes such as adventure and creative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->