### PR TITLE
feat: Setting to disable the rendering of unknown entity placeholders

### DIFF
--- a/renderer/viewer/lib/entities.ts
+++ b/renderer/viewer/lib/entities.ts
@@ -183,6 +183,8 @@ function getEntityMesh (entity, world, options, overrides) {
     }
   }
 
+  if (!world.config.unknownEntityDisplay) return
+
   const geometry = new THREE.BoxGeometry(entity.width, entity.height, entity.width)
   geometry.translate(0, entity.height / 2, 0)
   const material = new THREE.MeshBasicMaterial({ color: 0xff_00_ff })
@@ -983,7 +985,7 @@ export class Entities extends EventEmitter {
     const itemObject = this.getItemMesh(item, {
       'minecraft:display_context': 'thirdperson',
     })
-    if (itemObject) {
+    if (itemObject?.mesh) {
       entityMesh.traverse(c => {
         if (c.name.toLowerCase() === parentName) {
           const group = new THREE.Object3D()

--- a/renderer/viewer/lib/worldrendererCommon.ts
+++ b/renderer/viewer/lib/worldrendererCommon.ts
@@ -37,6 +37,7 @@ export const defaultWorldRendererConfig = {
   numWorkers: 4,
   isPlayground: false,
   renderEars: true,
+  unknownEntityDisplay: true,
   // game renderer setting actually
   showHand: false,
   viewBobbing: false

--- a/src/optionsGuiScheme.tsx
+++ b/src/optionsGuiScheme.tsx
@@ -87,6 +87,9 @@ export const guiOptionsScheme: {
       },
       starfieldRendering: {},
       renderEntities: {},
+      unknownEntityDisplay: {
+        tooltip: 'Show or hide the placeholder box and entity name text for unknown entities',
+      },
       keepChunksDistance: {
         max: 5,
         unit: '',

--- a/src/optionsStorage.ts
+++ b/src/optionsStorage.ts
@@ -87,6 +87,7 @@ const defaultOptions = {
   /** Actually might be useful */
   showCursorBlockInSpectator: false,
   renderEntities: true,
+  unknownEntityDisplay: true,
   smoothLighting: true,
   newVersionsLighting: false,
   chatSelect: true,

--- a/src/watchOptions.ts
+++ b/src/watchOptions.ts
@@ -99,5 +99,6 @@ export const watchOptionsAfterWorldViewInit = () => {
     viewer.world.config.renderEars = o.renderEars
     viewer.world.config.showHand = o.showHand
     viewer.world.config.viewBobbing = o.viewBobbing
+    viewer.world.config.unknownEntityDisplay = options.unknownEntityDisplay
   })
 }


### PR DESCRIPTION
This adds a setting to disable the rendering of the unknown entity placeholders. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new setting to control the display of unknown entities. Users can now toggle the visibility of placeholder boxes and entity names.

- **Enhancements**
  - Improved the error handling process to ensure smoother behavior when unknown entity data isn’t available.
  - Ensured that configuration changes update reactively, aligning the view with current user preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->