### PR TITLE
fix: respect main menu links display from config

### DIFF
--- a/src/react/MainMenu.tsx
+++ b/src/react/MainMenu.tsx
@@ -7,6 +7,7 @@ import Button from './Button'
 import ButtonWithTooltip from './ButtonWithTooltip'
 import { pixelartIcons } from './PixelartIcon'
 import useLongPress from './useLongPress'
+import PauseLinkButtons from './PauseLinkButtons'
 
 type Action = (e: React.MouseEvent<HTMLButtonElement>) => void
 
@@ -15,7 +16,6 @@ interface Props {
   singleplayerAction?: Action
   optionsAction?: Action
   githubAction?: Action
-  linksButton?: JSX.Element
   openFileAction?: Action
   mapsProvider?: string
   versionStatus?: string
@@ -35,7 +35,6 @@ export default ({
   singleplayerAction,
   optionsAction,
   githubAction,
-  linksButton,
   openFileAction,
   versionText,
   onVersionTextClick,
@@ -143,16 +142,7 @@ export default ({
           Options
         </Button>
         <div className={styles['menu-row']}>
-          <ButtonWithTooltip
-            initialTooltip={{
-              content: 'Report bugs or request features!',
-            }}
-            style={{ width: '98px' }}
-            onClick={githubAction}
-          >
-            GitHub
-          </ButtonWithTooltip>
-          {linksButton}
+          <PauseLinkButtons />
         </div>
       </div>
 

--- a/src/react/MainMenuRenderApp.tsx
+++ b/src/react/MainMenuRenderApp.tsx
@@ -8,7 +8,6 @@ import { setLoadingScreenStatus } from '../appStatus'
 import { openFilePicker, copyFilesAsync, mkdirRecursive, openWorldDirectory, removeFileRecursiveAsync } from '../browserfs'
 
 import MainMenu from './MainMenu'
-import { DiscordButton } from './DiscordButton'
 
 const isMainMenu = () => {
   return activeModalStack.length === 0 && !miscUiState.gameLoaded
@@ -145,7 +144,6 @@ export default () => {
         }}
         githubAction={() => openGithub()}
         optionsAction={() => openOptionsMenu('main')}
-        linksButton={<DiscordButton />}
         bottomRightLinks={process.env.MAIN_MENU_LINKS}
         openFileAction={e => {
           if (!!window.showDirectoryPicker && !e.shiftKey) {

--- a/src/react/PauseLinkButtons.tsx
+++ b/src/react/PauseLinkButtons.tsx
@@ -1,0 +1,50 @@
+import { useSnapshot } from 'valtio'
+import { openURL } from 'renderer/viewer/lib/simpleUtils'
+import { ErrorBoundary } from '@zardoy/react-util'
+import { miscUiState } from '../globalState'
+import { openGithub } from '../utils'
+import Button from './Button'
+import { DiscordButton } from './DiscordButton'
+import styles from './PauseScreen.module.css'
+
+function PauseLinkButtonsInner () {
+  const { appConfig } = useSnapshot(miscUiState)
+  const pauseLinksConfig = appConfig?.pauseLinks
+
+  if (!pauseLinksConfig) return null
+
+  const renderButton = (button: Record<string, any>, style: React.CSSProperties, key: number) => {
+    if (button.type === 'discord') {
+      return <DiscordButton key={key} style={style} text={button.text}/>
+    }
+    if (button.type === 'github') {
+      return <Button key={key} className="button" style={style} onClick={() => openGithub()}>{button.text ?? 'GitHub'}</Button>
+    }
+    if (button.type === 'url' && button.text) {
+      return <Button key={key} className="button" style={style} onClick={() => openURL(button.url)}>{button.text}</Button>
+    }
+    return null
+  }
+
+  return (
+    <>
+      {pauseLinksConfig.map((row, i) => {
+        const style = { width: (204 / row.length - (row.length > 1 ? 4 : 0)) + 'px' }
+        return (
+          <div key={i} className={styles.row}>
+            {row.map((button, k) => renderButton(button, style, k))}
+          </div>
+        )
+      })}
+    </>
+  )
+}
+
+export default () => {
+  return <ErrorBoundary renderError={(error) => {
+    console.error(error)
+    return null
+  }}>
+    <PauseLinkButtonsInner />
+  </ErrorBoundary>
+}

--- a/src/react/PauseScreen.tsx
+++ b/src/react/PauseScreen.tsx
@@ -34,6 +34,7 @@ import { DiscordButton } from './DiscordButton'
 import { showNotification } from './NotificationProvider'
 import { appStatusState, reconnectReload } from './AppStatusProvider'
 import NetworkStatus from './NetworkStatus'
+import PauseLinkButtons from './PauseLinkButtons'
 
 const waitForPotentialRender = async () => {
   return new Promise<void>(resolve => {
@@ -227,26 +228,6 @@ export default () => {
 
   if (!isModalActive) return null
 
-  const pauseLinks: React.ReactNode[] = []
-  const pauseLinksConfig = miscUiState.appConfig?.pauseLinks
-  if (pauseLinksConfig) {
-    for (const [i, row] of pauseLinksConfig.entries()) {
-      const rowButtons: React.ReactNode[] = []
-      for (const [k, button] of row.entries()) {
-        const key = `${i}-${k}`
-        const style = { width: (204 / row.length - (row.length > 1 ? 4 : 0)) + 'px' }
-        if (button.type === 'discord') {
-          rowButtons.push(<DiscordButton key={key} style={style} text={button.text}/>)
-        } else if (button.type === 'github') {
-          rowButtons.push(<Button key={key} className="button" style={style} onClick={() => openGithub()}>{button.text ?? 'GitHub'}</Button>)
-        } else if (button.type === 'url' && button.text) {
-          rowButtons.push(<Button key={key} className="button" style={style} onClick={() => openURL(button.url)}>{button.text}</Button>)
-        }
-      }
-      pauseLinks.push(<div className={styles.row}>{rowButtons}</div>)
-    }
-  }
-
   return <Screen title='Game Menu'>
     <div style={{ position: 'fixed', top: '5px', left: 'calc(env(safe-area-inset-left) + 5px)', display: 'flex', flexDirection: 'column', gap: '5px' }}>
       <Button
@@ -277,7 +258,7 @@ export default () => {
     </ErrorBoundary>
     <div className={styles.pause_container}>
       <Button className="button" style={{ width: '204px' }} onClick={onReturnPress}>Back to Game</Button>
-      {pauseLinks}
+      <PauseLinkButtons />
       <Button className="button" style={{ width: '204px' }} onClick={() => openOptionsMenu('main')}>Options</Button>
       {singleplayer ? (
         <div className={styles.row}>


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Introduced `PauseLinkButtons` component for dynamic link rendering.

- Replaced hardcoded link buttons with `PauseLinkButtons` in `MainMenu` and `PauseScreen`.

- Removed redundant `linksButton` prop and associated logic.

- Simplified and centralized link button rendering logic.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MainMenu.tsx</strong><dd><code>Refactored main menu link rendering logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/react/MainMenu.tsx

<li>Removed <code>linksButton</code> prop and its usage.<br> <li> Replaced hardcoded GitHub button with <code>PauseLinkButtons</code>.<br> <li> Simplified link rendering logic in the main menu.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/308/files#diff-4762990358aec7e70d799616f5aeb7309791a62848eb54c4499aea2f58e5cd10">+2/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MainMenuRenderApp.tsx</strong><dd><code>Removed unused `linksButton` prop in MainMenuRenderApp</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/react/MainMenuRenderApp.tsx

<li>Removed <code>linksButton</code> prop assignment.<br> <li> Cleaned up unused <code>DiscordButton</code> import.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/308/files#diff-3fddf387f865f73ebd6d1d7556777d71e5400ee80c4755e6585deb261c2e3c0b">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PauseLinkButtons.tsx</strong><dd><code>Added `PauseLinkButtons` component for dynamic link rendering</code></dd></summary>
<hr>

src/react/PauseLinkButtons.tsx

<li>Added new <code>PauseLinkButtons</code> component.<br> <li> Dynamically renders buttons based on configuration.<br> <li> Handles Discord, GitHub, and custom URL buttons.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/308/files#diff-f077377996d8194661ec52321c2806c71cff491947fbc87952079c2e8d58b787">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PauseScreen.tsx</strong><dd><code>Refactored pause screen link rendering logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/react/PauseScreen.tsx

<li>Replaced inline link rendering logic with <code>PauseLinkButtons</code>.<br> <li> Removed redundant <code>pauseLinks</code> logic.<br> <li> Simplified pause screen link rendering.


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/308/files#diff-99a6412a94e0c80157501dcaf252db4491920e1bfa0fae935efd3cb2debea1c6">+2/-21</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new component to dynamically render pause links, offering actions like Discord connection, GitHub navigation, and URL access based on configuration.

- **Refactor**
  - Replaced the previous link button mechanism in the menu and pause screen with the new pause links approach, streamlining the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->