### PR TITLE
feat: Combine IP and port input fields

### DIFF
--- a/src/react/AddServerOrConnect.tsx
+++ b/src/react/AddServerOrConnect.tsx
@@ -46,7 +46,7 @@ export default ({ onBack, onConfirm, title = 'Add a Server', initialData, parseQ
   const parsedInitialIp = parseServerAddress(initialData?.ip)
 
   const [serverName, setServerName] = React.useState(initialData?.name ?? qsParamName ?? '')
-  const [serverIp, setServerIp] = React.useState(parsedQsIp.host || parsedInitialIp.serverIpFull || '')
+  const [serverIp, setServerIp] = React.useState(parsedQsIp.serverIpFull || parsedInitialIp.serverIpFull || '')
   const [versionOverride, setVersionOverride] = React.useState(initialData?.versionOverride ?? /* legacy */ initialData?.['version'] ?? qsParamVersion ?? '')
   const [proxyOverride, setProxyOverride] = React.useState(initialData?.proxyOverride ?? qsParamProxy ?? '')
   const [usernameOverride, setUsernameOverride] = React.useState(initialData?.usernameOverride ?? qsParamUsername ?? '')
@@ -125,6 +125,9 @@ export default ({ onBack, onConfirm, title = 'Add a Server', initialData, parseQ
   }, [])
 
   const displayConnectButton = qsParamIp
+  const serverExamples = ['example.com:25565', 'play.hypixel.net', 'ws://play.pcm.gg']
+  // pick random example
+  const example = serverExamples[Math.floor(Math.random() * serverExamples.length)]
 
   return <Screen title={qsParamIp ? 'Connect to Server' : title} backdrop>
     <form
@@ -159,7 +162,7 @@ export default ({ onBack, onConfirm, title = 'Add a Server', initialData, parseQ
             setServerOnline(false)
           }}
           validateInput={serverOnline === null || fetchedServerInfoIp !== serverIp ? undefined : validateServerIp}
-          placeholder="example.com:25565"
+          placeholder={example}
         />
         {!lockConnect && <>
           <div style={{ display: 'flex', justifyContent: 'center' }}>

--- a/src/react/AddServerOrConnect.tsx
+++ b/src/react/AddServerOrConnect.tsx
@@ -148,11 +148,6 @@ export default ({ onBack, onConfirm, title = 'Add a Server', initialData, parseQ
         })
       }}
       >
-        {!lockConnect && <>
-          <div style={{ display: 'flex', justifyContent: 'center' }}>
-            <InputWithLabel label="Server Name" value={serverName} onChange={({ target: { value } }) => setServerName(value)} placeholder='Defaults to IP' />
-          </div>
-        </>}
         <InputWithLabel
           required
           label="Server IP"
@@ -166,6 +161,11 @@ export default ({ onBack, onConfirm, title = 'Add a Server', initialData, parseQ
           validateInput={serverOnline === null || fetchedServerInfoIp !== serverIp ? undefined : validateServerIp}
           placeholder="IP address (e.g. 192.168.0.82:25566)"
         />
+        {!lockConnect && <>
+          <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <InputWithLabel label="Server Name" value={serverName} onChange={({ target: { value } }) => setServerName(value)} placeholder='Defaults to IP' />
+          </div>
+        </>}
         {isSmallHeight ? <div style={{ gridColumn: 'span 2', marginTop: 10, }} /> : <div style={{ gridColumn: smallWidth ? '' : 'span 2' }}>Overrides:</div>}
         <div style={{
           display: 'flex',

--- a/src/react/AddServerOrConnect.tsx
+++ b/src/react/AddServerOrConnect.tsx
@@ -46,7 +46,7 @@ export default ({ onBack, onConfirm, title = 'Add a Server', initialData, parseQ
   const parsedInitialIp = parseServerAddress(initialData?.ip)
 
   const [serverName, setServerName] = React.useState(initialData?.name ?? qsParamName ?? '')
-  const [serverIp, setServerIp] = React.useState(parsedQsIp.host || parsedInitialIp.host || '')
+  const [serverIp, setServerIp] = React.useState(parsedQsIp.host || parsedInitialIp.serverIpFull || '')
   const [versionOverride, setVersionOverride] = React.useState(initialData?.versionOverride ?? /* legacy */ initialData?.['version'] ?? qsParamVersion ?? '')
   const [proxyOverride, setProxyOverride] = React.useState(initialData?.proxyOverride ?? qsParamProxy ?? '')
   const [usernameOverride, setUsernameOverride] = React.useState(initialData?.usernameOverride ?? qsParamUsername ?? '')

--- a/src/react/AddServerOrConnect.tsx
+++ b/src/react/AddServerOrConnect.tsx
@@ -149,7 +149,7 @@ export default ({ onBack, onConfirm, title = 'Add a Server', initialData, parseQ
       }}
       >
         {!lockConnect && <>
-          <div style={{ gridColumn: smallWidth ? '' : 'span 2', display: 'flex', justifyContent: 'center' }}>
+          <div style={{ display: 'flex', justifyContent: 'center' }}>
             <InputWithLabel label="Server Name" value={serverName} onChange={({ target: { value } }) => setServerName(value)} placeholder='Defaults to IP' />
           </div>
         </>}

--- a/src/react/AddServerOrConnect.tsx
+++ b/src/react/AddServerOrConnect.tsx
@@ -47,7 +47,6 @@ export default ({ onBack, onConfirm, title = 'Add a Server', initialData, parseQ
 
   const [serverName, setServerName] = React.useState(initialData?.name ?? qsParamName ?? '')
   const [serverIp, setServerIp] = React.useState(parsedQsIp.host || parsedInitialIp.host || '')
-  const [serverPort, setServerPort] = React.useState(parsedQsIp.port || parsedInitialIp.port || '')
   const [versionOverride, setVersionOverride] = React.useState(initialData?.versionOverride ?? /* legacy */ initialData?.['version'] ?? qsParamVersion ?? '')
   const [proxyOverride, setProxyOverride] = React.useState(initialData?.proxyOverride ?? qsParamProxy ?? '')
   const [usernameOverride, setUsernameOverride] = React.useState(initialData?.usernameOverride ?? qsParamUsername ?? '')
@@ -61,7 +60,7 @@ export default ({ onBack, onConfirm, title = 'Add a Server', initialData, parseQ
   const noAccountSelected = accountIndex === -1
   const authenticatedAccountOverride = noAccountSelected ? undefined : freshAccount ? true : accounts?.[accountIndex]
 
-  let ipFinal = serverIp.includes(':') ? serverIp : `${serverIp}${serverPort ? `:${serverPort}` : ''}`
+  let ipFinal = serverIp
   ipFinal = ipFinal.replace(/:$/, '')
   const commonUseOptions: BaseServerInfo = {
     name: serverName,
@@ -165,8 +164,8 @@ export default ({ onBack, onConfirm, title = 'Add a Server', initialData, parseQ
             setServerOnline(false)
           }}
           validateInput={serverOnline === null || fetchedServerInfoIp !== serverIp ? undefined : validateServerIp}
+          placeholder="IP address (e.g. 192.168.0.82:25566)"
         />
-        <InputWithLabel label="Server Port" value={serverPort} disabled={lockConnect && parsedQsIp.port !== null} onChange={({ target: { value } }) => setServerPort(value)} placeholder={serverIp.startsWith('ws://') || serverIp.startsWith('wss://') ? '' : '25565'} />
         {isSmallHeight ? <div style={{ gridColumn: 'span 2', marginTop: 10, }} /> : <div style={{ gridColumn: smallWidth ? '' : 'span 2' }}>Overrides:</div>}
         <div style={{
           display: 'flex',

--- a/src/react/AddServerOrConnect.tsx
+++ b/src/react/AddServerOrConnect.tsx
@@ -159,7 +159,7 @@ export default ({ onBack, onConfirm, title = 'Add a Server', initialData, parseQ
             setServerOnline(false)
           }}
           validateInput={serverOnline === null || fetchedServerInfoIp !== serverIp ? undefined : validateServerIp}
-          placeholder="IP address (e.g. 192.168.0.82:25566)"
+          placeholder="example.com:25565"
         />
         {!lockConnect && <>
           <div style={{ display: 'flex', justifyContent: 'center' }}>


### PR DESCRIPTION
### **User description**
This PR merges the separate input fields for IP address and port into a single combined field for better UX and cleaner layout.


___

### **PR Type**
Enhancement


___

### **Description**
- Merged IP address and port inputs into a single field

- Removed separate server port input and related logic

- Updated placeholder to guide combined input format


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AddServerOrConnect.tsx</strong><dd><code>Combine IP and port into a single input field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/react/AddServerOrConnect.tsx

<li>Removed separate server port state and input field<br> <li> Updated logic to treat <code>serverIp</code> as combined IP:port<br> <li> Changed placeholder to show combined IP:port example<br> <li> Simplified final IP construction logic


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/345/files#diff-9dbc0f17c726d8e350834102ba9f20348c4551e350efb06b81560a70c051bd73">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the "Server IP" input field to accept both IP address and port in a single entry, with a new placeholder example for guidance.

- **Refactor**
  - Simplified the server connection form by removing the separate "Server Port" input field. Users now enter the full server address (including port, if needed) in one field.
  - Repositioned the "Server Name" input to appear conditionally below the "Server IP" field for improved layout and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->