### PR TITLE
server name field "flex-start" now

### DIFF
--- a/src/react/AddServerOrConnect.tsx
+++ b/src/react/AddServerOrConnect.tsx
@@ -165,7 +165,7 @@ export default ({ onBack, onConfirm, title = 'Add a Server', initialData, parseQ
           placeholder={example}
         />
         {!lockConnect && <>
-          <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <div style={{ display: 'flex' }}>
             <InputWithLabel label="Server Name" value={serverName} onChange={({ target: { value } }) => setServerName(value)} placeholder='Defaults to IP' />
           </div>
         </>}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Adjusted server name input alignment to flex-start

- Improved UI consistency for server name field


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AddServerOrConnect.tsx</strong><dd><code>Align server name input container to flex-start</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/react/AddServerOrConnect.tsx

<li>Changed server name input container alignment from center to <br>flex-start<br> <li> Enhanced layout consistency for server name field


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/351/files#diff-9dbc0f17c726d8e350834102ba9f20348c4551e350efb06b81560a70c051bd73">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the layout of the "Server Name" input field so that it is no longer centered horizontally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->