### PR TITLE
Fixed button shown even when cursor is not over the entity (e.g., a video)

### DIFF
--- a/src/react/TouchInteractionHint.tsx
+++ b/src/react/TouchInteractionHint.tsx
@@ -57,6 +57,9 @@ export default () => {
   if (!usingTouch || touchInteractionType !== 'classic' || modalStack.length > 0) return null
   if (!hintText && !entityName) return null
 
+  // need to hide "Use" button if there isn't an entity name, but there is a hint text
+  if (!entityName) return null
+
   return (
     <div
       className={`${styles.hint_container} interaction-hint`}


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixes "Use" button displaying when cursor not over entity

- Adds check to hide button if no entity name present


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TouchInteractionHint.tsx</strong><dd><code>Hide "Use" button when entity is not hovered</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/react/TouchInteractionHint.tsx

<li>Adds condition to hide "Use" button if no entity name is present<br> <li> Prevents button from showing when only hint text exists


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/356/files#diff-bdd482c76c027cbb46acb64a169fd2d0f3eddfee1ab457f23f9a6a155374bcf3">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the display logic for the interaction hint, ensuring the "Use" button is hidden when there is no associated entity name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->