### PR TITLE
feat(config): Add support for remote dynamic splash text

### DIFF
--- a/config.json
+++ b/config.json
@@ -26,6 +26,7 @@
     }
   ],
   "rightSideText": "A Minecraft client clone in the browser!",
+  "splashTextFallback": "GEN is cooking",
   "splashText": "https://jsonplaceholder.typicode.com/posts/1",
   "pauseLinks": [
     [

--- a/config.json
+++ b/config.json
@@ -26,8 +26,8 @@
     }
   ],
   "rightSideText": "A Minecraft client clone in the browser!",
+  "splashText": "GEN is cooking",
   "splashTextFallback": "Welcome!",
-  "splashText": "https://jsonplaceholder.typicode.com/posts/1",
   "pauseLinks": [
     [
       {

--- a/config.json
+++ b/config.json
@@ -26,7 +26,7 @@
     }
   ],
   "rightSideText": "A Minecraft client clone in the browser!",
-  "splashTextFallback": "GEN is cooking",
+  "splashTextFallback": "Welcome!",
   "splashText": "https://jsonplaceholder.typicode.com/posts/1",
   "pauseLinks": [
     [

--- a/config.json
+++ b/config.json
@@ -26,7 +26,7 @@
     }
   ],
   "rightSideText": "A Minecraft client clone in the browser!",
-  "splashText": "https://jsonplaceholder.typicode.com/posts/1",
+  "splashText": "The sunset is coming!",
   "splashTextFallback": "Welcome!",
   "pauseLinks": [
     [

--- a/config.json
+++ b/config.json
@@ -26,7 +26,7 @@
     }
   ],
   "rightSideText": "A Minecraft client clone in the browser!",
-  "splashText": "Gen is cooking!",
+  "splashText": "https://jsonplaceholder.typicode.com/posts/1",
   "pauseLinks": [
     [
       {

--- a/config.json
+++ b/config.json
@@ -26,7 +26,7 @@
     }
   ],
   "rightSideText": "A Minecraft client clone in the browser!",
-  "splashText": "GEN is cooking",
+  "splashText": "https://jsonplaceholder.typicode.com/posts/1",
   "splashTextFallback": "Welcome!",
   "pauseLinks": [
     [

--- a/src/appConfig.ts
+++ b/src/appConfig.ts
@@ -24,6 +24,7 @@ export type AppConfig = {
   // hideSettings?: Record<string, boolean>
   allowAutoConnect?: boolean
   splashText?: string
+  splashTextFallback?: string
   pauseLinks?: Array<Array<Record<string, any>>>
   keybindings?: Record<string, any>
   defaultLanguage?: string

--- a/src/react/MainMenu.tsx
+++ b/src/react/MainMenu.tsx
@@ -77,7 +77,7 @@ export default ({
     }
 
     return appConfig?.splashTextFallback || ''
-  }, [appConfig])
+  }, [])
 
   useEffect(() => {
     const configSplashFromApp = appConfig?.splashText

--- a/src/react/MainMenu.tsx
+++ b/src/react/MainMenu.tsx
@@ -1,9 +1,10 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { openURL } from 'renderer/viewer/lib/simpleUtils'
 import { useSnapshot } from 'valtio'
 import { haveDirectoryPicker } from '../utils'
 import { ConnectOptions } from '../connect'
 import { miscUiState } from '../globalState'
+import { isRemoteSplashText, loadRemoteSplashText } from '../utils/splashText'
 import styles from './mainMenu.module.css'
 import Button from './Button'
 import ButtonWithTooltip from './ButtonWithTooltip'
@@ -47,6 +48,19 @@ export default ({
   singleplayerAvailable = true
 }: Props) => {
   const { appConfig } = useSnapshot(miscUiState)
+  const [splashText, setSplashText] = useState(appConfig?.splashText || '')
+
+  useEffect(() => {
+    const loadSplashText = async () => {
+      if (appConfig?.splashText && isRemoteSplashText(appConfig.splashText)) {
+        const text = await loadRemoteSplashText(appConfig.splashText)
+        setSplashText(text)
+      } else {
+        setSplashText(appConfig?.splashText || '')
+      }
+    }
+    void loadSplashText()
+  }, [appConfig?.splashText])
 
   if (!bottomRightLinks?.trim()) bottomRightLinks = undefined
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
@@ -75,7 +89,7 @@ export default ({
   const connectToServerLongPress = useLongPress(
     () => {
       if (process.env.NODE_ENV === 'development') {
-      // Connect to <origin>:25565
+        // Connect to <origin>:25565
         const origin = window.location.hostname
         const connectOptions: ConnectOptions = {
           server: `${origin}:25565`,
@@ -93,7 +107,7 @@ export default ({
       <div className={styles['game-title']}>
         <div className={styles.minecraft}>
           <div className={styles.edition} />
-          <span className={styles.splash}>{appConfig?.splashText}</span>
+          <span className={styles.splash}>{splashText}</span>
         </div>
       </div>
 

--- a/src/react/MainMenu.tsx
+++ b/src/react/MainMenu.tsx
@@ -52,11 +52,16 @@ export default ({
 
   useEffect(() => {
     const loadSplashText = async () => {
-      if (appConfig?.splashText && isRemoteSplashText(appConfig.splashText)) {
-        const text = await loadRemoteSplashText(appConfig.splashText)
-        setSplashText(text)
-      } else {
-        setSplashText(appConfig?.splashText || '')
+      try {
+        if (appConfig?.splashText && isRemoteSplashText(appConfig.splashText)) {
+          const text = await loadRemoteSplashText(appConfig.splashText)
+          setSplashText(text)
+        } else {
+          setSplashText(appConfig?.splashText || '')
+        }
+      } catch (error) {
+        console.error('Failed to load splash text:', error)
+        setSplashText('Error loading splash text')
       }
     }
     void loadSplashText()

--- a/src/utils/splashText.ts
+++ b/src/utils/splashText.ts
@@ -1,5 +1,5 @@
 const MAX_WORDS = 5
-const HTTPS_REGEX = /^https?:\/\//
+const HTTPS_REGEX = /^https?:\/\/[-\w@:%.+~#=]{1,256}\.[a-zA-Z\d()]{1,6}\b([-\w()@:%+.~#?&/=]*)$/
 
 const limitWords = (text: string): string => {
   const words = text.split(/\s+/)
@@ -19,6 +19,8 @@ export const loadRemoteSplashText = async (url: string): Promise<string> => {
     if (!response.ok) {
       throw new Error(`Failed to fetch splash text: ${response.statusText}`)
     }
+
+    const clonedResponse = response.clone()
     try {
       const json = await response.json()
 
@@ -32,8 +34,7 @@ export const loadRemoteSplashText = async (url: string): Promise<string> => {
 
       return limitWords(String(json))
     } catch (jsonError) {
-
-      const text = await response.text()
+      const text = await clonedResponse.text()
       return limitWords(text.trim())
     }
   } catch (error) {

--- a/src/utils/splashText.ts
+++ b/src/utils/splashText.ts
@@ -1,17 +1,15 @@
 const MAX_WORDS = 5
 const HTTPS_REGEX = /^https?:\/\/[-\w@:%.+~#=]{1,256}\.[a-zA-Z\d()]{1,6}\b([-\w()@:%+.~#?&/=]*)$/
 const TIMEOUT_MS = 5000
-
-const sanitizeText = (text: string): string => {
-  return text.replaceAll(/<[^>]*>/g, '').replaceAll(/[^\w\s.,!?-]/g, '')
-}
+const SPLASH_CACHE_KEY = 'minecraft_splash_text_cache'
+const SPLASH_URL_KEY = 'minecraft_splash_url'
 
 const limitWords = (text: string): string => {
   const words = text.split(/\s+/)
   if (words.length <= MAX_WORDS) {
-    return sanitizeText(text)
+    return text
   }
-  return sanitizeText(words.slice(0, MAX_WORDS).join(' ') + '...')
+  return words.slice(0, MAX_WORDS).join(' ') + '...'
 }
 
 export const isRemoteSplashText = (text: string): boolean => {
@@ -49,4 +47,51 @@ export const loadRemoteSplashText = async (url: string): Promise<string> => {
     console.error('Error loading remote splash text:', error)
     return 'Failed to load splash text!'
   }
+}
+
+export const cacheSourceUrl = (url: string): void => {
+  localStorage.setItem(SPLASH_URL_KEY, url)
+}
+
+export const hasSourceUrlChanged = (newUrl?: string): boolean => {
+  const cachedUrl = localStorage.getItem(SPLASH_URL_KEY)
+
+  if ((!cachedUrl && newUrl) || (cachedUrl && !newUrl)) {
+    return true
+  }
+
+  return cachedUrl !== newUrl
+}
+
+export const clearSplashCache = (): void => {
+  localStorage.removeItem(SPLASH_CACHE_KEY)
+}
+
+export const getCachedSplashText = (): string | null => {
+  return localStorage.getItem(SPLASH_CACHE_KEY)
+}
+
+export const cacheSplashText = (text: string): void => {
+  localStorage.setItem(SPLASH_CACHE_KEY, text)
+}
+
+export const getDisplayText = (splashText?: string, fallbackText?: string): string => {
+  const cachedText = getCachedSplashText()
+
+  if (cachedText) return cachedText
+
+  if (fallbackText) return fallbackText
+
+  if (splashText && isRemoteSplashText(splashText)) return ''
+
+  return splashText || ''
+}
+
+export const getDirectDisplayText = (splashText?: string, fallbackText?: string): string => {
+
+  if (splashText && !isRemoteSplashText(splashText)) return splashText
+
+  if (fallbackText) return fallbackText
+
+  return ''
 }

--- a/src/utils/splashText.ts
+++ b/src/utils/splashText.ts
@@ -54,20 +54,6 @@ export const cacheSourceUrl = (url: string): void => {
   localStorage.setItem(SPLASH_URL_KEY, url)
 }
 
-export const hasSourceUrlChanged = (newUrl?: string): boolean => {
-  const cachedUrl = localStorage.getItem(SPLASH_URL_KEY)
-
-  if (!cachedUrl && !newUrl) {
-    return false
-  }
-
-  if ((!cachedUrl && newUrl) || (cachedUrl && !newUrl)) {
-    return true
-  }
-
-  return cachedUrl !== newUrl
-}
-
 export const clearSplashCache = (): void => {
   localStorage.removeItem(SPLASH_CACHE_KEY)
 }
@@ -78,25 +64,4 @@ export const getCachedSplashText = (): string | null => {
 
 export const cacheSplashText = (text: string): void => {
   localStorage.setItem(SPLASH_CACHE_KEY, text)
-}
-
-export const getDisplayText = (splashText?: string, fallbackText?: string): string => {
-  const cachedText = getCachedSplashText()
-
-  if (cachedText) return cachedText
-
-  if (fallbackText) return fallbackText
-
-  if (splashText && isRemoteSplashText(splashText)) return ''
-
-  return splashText || ''
-}
-
-export const getDirectDisplayText = (splashText?: string, fallbackText?: string): string => {
-
-  if (splashText && !isRemoteSplashText(splashText)) return splashText
-
-  if (fallbackText) return fallbackText
-
-  return ''
 }

--- a/src/utils/splashText.ts
+++ b/src/utils/splashText.ts
@@ -13,6 +13,7 @@ const limitWords = (text: string): string => {
 }
 
 export const isRemoteSplashText = (text: string): boolean => {
+  if (!text) return false
   return HTTPS_REGEX.test(text)
 }
 
@@ -55,6 +56,10 @@ export const cacheSourceUrl = (url: string): void => {
 
 export const hasSourceUrlChanged = (newUrl?: string): boolean => {
   const cachedUrl = localStorage.getItem(SPLASH_URL_KEY)
+
+  if (!cachedUrl && !newUrl) {
+    return false
+  }
 
   if ((!cachedUrl && newUrl) || (cachedUrl && !newUrl)) {
     return true

--- a/src/utils/splashText.ts
+++ b/src/utils/splashText.ts
@@ -1,12 +1,17 @@
 const MAX_WORDS = 5
 const HTTPS_REGEX = /^https?:\/\/[-\w@:%.+~#=]{1,256}\.[a-zA-Z\d()]{1,6}\b([-\w()@:%+.~#?&/=]*)$/
+const TIMEOUT_MS = 5000
+
+const sanitizeText = (text: string): string => {
+  return text.replaceAll(/<[^>]*>/g, '').replaceAll(/[^\w\s.,!?-]/g, '')
+}
 
 const limitWords = (text: string): string => {
   const words = text.split(/\s+/)
   if (words.length <= MAX_WORDS) {
-    return text
+    return sanitizeText(text)
   }
-  return words.slice(0, MAX_WORDS).join(' ') + '...'
+  return sanitizeText(words.slice(0, MAX_WORDS).join(' ') + '...')
 }
 
 export const isRemoteSplashText = (text: string): boolean => {
@@ -15,7 +20,10 @@ export const isRemoteSplashText = (text: string): boolean => {
 
 export const loadRemoteSplashText = async (url: string): Promise<string> => {
   try {
-    const response = await fetch(url)
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS)
+    const response = await fetch(url, { signal: controller.signal })
+    clearTimeout(timeoutId)
     if (!response.ok) {
       throw new Error(`Failed to fetch splash text: ${response.statusText}`)
     }

--- a/src/utils/splashText.ts
+++ b/src/utils/splashText.ts
@@ -1,5 +1,5 @@
 const MAX_WORDS = 5
-const HTTPS_REGEX = /^https?:\/\/[-\w@:%.+~#=]{1,256}\.[a-zA-Z\d()]{1,6}\b([-\w()@:%+.~#?&/=]*)$/
+const HTTPS_REGEX = /^https?:\/\//
 const TIMEOUT_MS = 5000
 const SPLASH_CACHE_KEY = 'minecraft_splash_text_cache'
 const SPLASH_URL_KEY = 'minecraft_splash_url'

--- a/src/utils/splashText.ts
+++ b/src/utils/splashText.ts
@@ -1,0 +1,43 @@
+const MAX_WORDS = 5
+const HTTPS_REGEX = /^https?:\/\//
+
+const limitWords = (text: string): string => {
+  const words = text.split(/\s+/)
+  if (words.length <= MAX_WORDS) {
+    return text
+  }
+  return words.slice(0, MAX_WORDS).join(' ') + '...'
+}
+
+export const isRemoteSplashText = (text: string): boolean => {
+  return HTTPS_REGEX.test(text)
+}
+
+export const loadRemoteSplashText = async (url: string): Promise<string> => {
+  try {
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(`Failed to fetch splash text: ${response.statusText}`)
+    }
+    try {
+      const json = await response.json()
+
+      if (typeof json === 'object' && json !== null) {
+        if (json.title) return limitWords(json.title)
+        if (json.text) return limitWords(json.text)
+        if (json.message) return limitWords(json.message)
+
+        return limitWords(JSON.stringify(json))
+      }
+
+      return limitWords(String(json))
+    } catch (jsonError) {
+
+      const text = await response.text()
+      return limitWords(text.trim())
+    }
+  } catch (error) {
+    console.error('Error loading remote splash text:', error)
+    return 'Failed to load splash text!'
+  }
+}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add support for loading splash text from remote HTTP/HTTPS URLs

- Limit splash text to a maximum of 5 words

- Update main menu to display fetched or local splash text

- Change config to use a remote URL for splash text


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>splashText.ts</strong><dd><code>Add utilities for remote splash text loading and limiting</code></dd></summary>
<hr>

src/utils/splashText.ts

<li>Add utility to detect if splash text is a remote URL<br> <li> Implement async loading and word limiting for remote splash text<br> <li> Handle JSON and plain text responses gracefully<br> <li> Provide error handling for fetch failures


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/358/files#diff-52d1129d8a2455b43373ceaa3f4198ff1e1edbab1c366b971c15f80dce1e92f2">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MainMenu.tsx</strong><dd><code>Display remote or local splash text in main menu</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/react/MainMenu.tsx

<li>Integrate remote splash text loading into main menu<br> <li> Use state and effect to fetch and display splash text<br> <li> Replace direct config usage with fetched splash text


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/358/files#diff-4762990358aec7e70d799616f5aeb7309791a62848eb54c4499aea2f58e5cd10">+17/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.json</strong><dd><code>Use remote URL for splash text in config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config.json

- Change splashText value to a remote HTTP URL


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/358/files#diff-587cb980af76fdc7e52369fd0b9d926dff266976b6f8ac631e358fecc49ff8cf">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Splash text in the main menu now supports loading from a remote URL for dynamic updates.
  - Remote splash text is fetched with a word limit of five for concise display.
  - Added fallback splash text to ensure reliable display when remote loading fails.

- **Bug Fixes**
  - Enhanced splash text handling to update display correctly when configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->