### PR TITLE
fix: item textures in inventory break after loading resourcepack

### DIFF
--- a/src/inventoryWindows.ts
+++ b/src/inventoryWindows.ts
@@ -25,6 +25,7 @@ import { GeneralInputItem, getItemMetadata, getItemModelName, getItemNameRaw, Re
 const loadedImagesCache = new Map<string, HTMLImageElement>()
 const cleanLoadedImagesCache = () => {
   loadedImagesCache.delete('blocks')
+  loadedImagesCache.delete('items')
 }
 
 let lastWindow: ReturnType<typeof showInventory>
@@ -120,6 +121,7 @@ export const onGameLoad = () => {
   if (!appViewer.resourcesManager['_inventoryChangeTracked']) {
     appViewer.resourcesManager['_inventoryChangeTracked'] = true
     const texturesChanged = () => {
+      cleanLoadedImagesCache()
       if (!lastWindow) return
       upWindowItemsLocal()
       upJei(lastJeiSearch)


### PR DESCRIPTION
### **User description**
This fixes that applying a resource pack with custom item textures/model data would break item textures (both of modified items and Vanilla ones)

With the bug vs. after the fix:
![image](https://github.com/user-attachments/assets/1332e1ce-3efe-4b48-8d7b-98da8c78e701) ![image](https://github.com/user-attachments/assets/ca81ca9b-56b7-4fba-92e3-968bc0c630fd)

![image](https://github.com/user-attachments/assets/b8bfd5b5-d06a-4dfc-810f-43937b1647e6) ![image](https://github.com/user-attachments/assets/288cca93-9628-4266-b086-8357a8d6d0fd)

![image](https://github.com/user-attachments/assets/d869d7b4-fe56-446f-9cea-65993af2a8fb) ![image](https://github.com/user-attachments/assets/eb8d8007-b868-407c-8810-4aab10aa2939)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes item textures breaking after loading a resource pack

- Clears both 'blocks' and 'items' from the image cache on texture change

- Ensures inventory UI updates correctly after resource pack changes


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inventoryWindows.ts</strong><dd><code>Fix item texture cache invalidation on resource pack reload</code></dd></summary>
<hr>

src/inventoryWindows.ts

<li>Added cache clearing for 'items' textures alongside 'blocks'<br> <li> Ensured cache is cleared when textures change due to resource pack<br> <li> Improved inventory UI update logic after resource pack reload


</details>


  </td>
  <td><a href="https://github.com/zardoy/minecraft-web-client/pull/362/files#diff-ee8af923180e87f7f744f2e5c1c92be528626cf2a03b2e8e2bd7cba3874d94a1">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inventory UI refresh by ensuring cached images for both blocks and items are cleared when textures change, resulting in more accurate and up-to-date visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->