### PR TITLE
Add server-side logging and timeout option

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,9 +16,18 @@ try {
 const app = express()
 
 const isProd = process.argv.includes('--prod') || process.env.NODE_ENV === 'production'
+const timeoutIndex = process.argv.indexOf('--timeout')
 app.use(compression())
 app.use(cors())
-app.use(netApi({ allowOrigin: '*' }))
+app.use(netApi({
+  allowOrigin: '*',
+  log: process.argv.includes('--log') || process.env.LOG === 'true',
+  timeout: timeoutIndex > -1 && timeoutIndex + 1 < process.argv.length
+      ? parseInt(process.argv[timeoutIndex + 1])
+      : process.env.TIMEOUT
+          ? parseInt(process.env.TIMEOUT)
+          : 10000
+}))
 if (!isProd) {
   app.use('/sounds', express.static(path.join(__dirname, './generated/sounds/')))
 }

--- a/server.js
+++ b/server.js
@@ -17,16 +17,21 @@ const app = express()
 
 const isProd = process.argv.includes('--prod') || process.env.NODE_ENV === 'production'
 const timeoutIndex = process.argv.indexOf('--timeout')
+let timeout = timeoutIndex > -1 && timeoutIndex + 1 < process.argv.length
+    ? parseInt(process.argv[timeoutIndex + 1])
+    : process.env.TIMEOUT
+        ? parseInt(process.env.TIMEOUT)
+        : 10000
+if (isNaN(timeout) || timeout < 0) {
+  console.warn('Invalid timeout value provided, using default of 10000ms')
+  timeout = 10000
+}
 app.use(compression())
 app.use(cors())
 app.use(netApi({
   allowOrigin: '*',
   log: process.argv.includes('--log') || process.env.LOG === 'true',
-  timeout: timeoutIndex > -1 && timeoutIndex + 1 < process.argv.length
-      ? parseInt(process.argv[timeoutIndex + 1])
-      : process.env.TIMEOUT
-          ? parseInt(process.env.TIMEOUT)
-          : 10000
+  timeout
 }))
 if (!isProd) {
   app.use('/sounds', express.static(path.join(__dirname, './generated/sounds/')))


### PR DESCRIPTION
This adds parameters to set whether or not there should be logging (with `--log` or `LOG` env) and the amount of the timeout (with `--timeout` or `TIMEOUT` env) on the websocket proxy side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for enabling logging and customizing timeout settings for network API requests using command-line arguments or environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->