### PR TITLE
feat: Support nameTagVisibility option of teams

### DIFF
--- a/renderer/viewer/lib/basePlayerState.ts
+++ b/renderer/viewer/lib/basePlayerState.ts
@@ -1,5 +1,5 @@
 import { ItemSelector } from 'mc-assets/dist/itemDefinitions'
-import { GameMode } from 'mineflayer'
+import { GameMode, Team } from 'mineflayer'
 import { proxy } from 'valtio'
 import type { HandItemBlock } from '../three/holdingBlock'
 
@@ -49,6 +49,8 @@ export const getInitialPlayerState = () => proxy({
   heldItemOff: undefined as HandItemBlock | undefined,
 
   cameraSpectatingEntity: undefined as number | undefined,
+
+  team: undefined as Team | undefined,
 })
 
 export const getPlayerStateUtils = (reactive: PlayerStateReactive) => ({

--- a/renderer/viewer/lib/worldDataEmitter.ts
+++ b/renderer/viewer/lib/worldDataEmitter.ts
@@ -97,6 +97,7 @@ export class WorldDataEmitter extends (EventEmitter as new () => TypedEmitter<Wo
         ...e,
         pos: e.position,
         username: e.username,
+        team: bot.teamMap[e.username] || bot.teamMap[e.uuid],
         // set debugTree (obj) {
         //   e.debugTree = obj
         // }

--- a/renderer/viewer/three/entities.ts
+++ b/renderer/viewer/three/entities.ts
@@ -1121,7 +1121,7 @@ export class Entities {
       const nameTagVisibility = entityTeam?.nameTagVisibility || 'always'
       const showNameTag = nameTagVisibility === 'always' ||
         (nameTagVisibility === 'hideForOwnTeam' && entityTeam !== bot.teamMap[bot.username]) ||
-        (nameTagVisibility === 'hideForOtherTeams' && entityTeam === bot.teamMap[bot.username] || bot.teamMap[bot.username] === undefined)
+        (nameTagVisibility === 'hideForOtherTeams' && (entityTeam === bot.teamMap[bot.username] || bot.teamMap[bot.username] === undefined))
       entity.traverse(c => {
         if (c.name === 'nametag') {
           c.visible = showNameTag

--- a/renderer/viewer/three/entities.ts
+++ b/renderer/viewer/three/entities.ts
@@ -808,6 +808,8 @@ export class Entities {
           nameTag.position.y = playerObject.position.y + playerObject.scale.y * 16 + 3
           nameTag.renderOrder = 1000
 
+          nameTag.name = 'nametag'
+
           //@ts-expect-error
           wrapper.add(nameTag)
         }
@@ -1038,11 +1040,14 @@ export class Entities {
       e.username = entity.username
     }
 
-    if (entity.type === 'player' && entity.equipment && e.playerObject) {
-      const { playerObject } = e
-      playerObject.backEquipment = entity.equipment.some((item) => item?.name === 'elytra') ? 'elytra' : 'cape'
-      if (playerObject.cape.map === null) {
-        playerObject.cape.visible = false
+    if (entity.type === 'player' && e.playerObject) {
+      this.updateNameTagVisibility(e)
+      if (entity.equipment) {
+        const { playerObject } = e
+        playerObject.backEquipment = entity.equipment.some((item) => item?.name === 'elytra') ? 'elytra' : 'cape'
+        if (playerObject.cape.map === null) {
+          playerObject.cape.visible = false
+        }
       }
     }
 
@@ -1107,6 +1112,21 @@ export class Entities {
         mesh.material.needsUpdate = true
         mesh.visible = true
       }
+    }
+  }
+
+  updateNameTagVisibility (entity: SceneEntity) {
+    if (entity.playerObject && entity.username) {
+      const entityTeam = bot.teamMap[entity.username]
+      const nameTagVisibility = entityTeam?.nameTagVisibility || 'always'
+      const showNameTag = nameTagVisibility === 'always' ||
+        (nameTagVisibility === 'hideForOwnTeam' && entityTeam !== bot.teamMap[bot.username]) ||
+        (nameTagVisibility === 'hideForOtherTeams' && entityTeam === bot.teamMap[bot.username] || bot.teamMap[bot.username] === undefined)
+      entity.traverse(c => {
+        if (c.name === 'nametag') {
+          c.visible = showNameTag
+        }
+      })
     }
   }
 

--- a/renderer/viewer/three/entities.ts
+++ b/renderer/viewer/three/entities.ts
@@ -1120,14 +1120,6 @@ export class Entities {
 
     this.updateNameTagVisibility(e)
 
-    if (entity.type === 'player' && e.playerObject && entity.equipment) {
-      const { playerObject } = e
-      playerObject.backEquipment = entity.equipment.some((item) => item?.name === 'elytra') ? 'elytra' : 'cape'
-      if (playerObject.cape.map === null) {
-        playerObject.cape.visible = false
-      }
-    }
-
     this.updateEntityPosition(entity, justAdded, overrides)
   }
 

--- a/renderer/viewer/three/entities.ts
+++ b/renderer/viewer/three/entities.ts
@@ -16,6 +16,7 @@ import { Item } from 'prismarine-item'
 import { BlockModel } from 'mc-assets'
 import { isEntityAttackable } from 'mineflayer-mouse/dist/attackableEntity'
 import { Vec3 } from 'vec3'
+import { Team } from 'mineflayer'
 import { EntityMetadataVersions } from '../../../src/mcDataTypes'
 import { ItemSpecificContextProperties } from '../lib/basePlayerState'
 import { loadSkinImage, loadSkinFromUsername, stevePngUrl, steveTexture } from '../lib/utils/skins'
@@ -209,7 +210,7 @@ export type SceneEntity = THREE.Object3D & {
   username?: string
   uuid?: string
   additionalCleanup?: () => void
-  originalEntity: import('prismarine-entity').Entity & { delete?; pos?, name }
+  originalEntity: import('prismarine-entity').Entity & { delete?; pos?, name, team?: Team }
 }
 
 export class Entities {
@@ -1040,14 +1041,13 @@ export class Entities {
       e.username = entity.username
     }
 
-    if (entity.type === 'player' && e.playerObject) {
-      this.updateNameTagVisibility(e)
-      if (entity.equipment) {
-        const { playerObject } = e
-        playerObject.backEquipment = entity.equipment.some((item) => item?.name === 'elytra') ? 'elytra' : 'cape'
-        if (playerObject.cape.map === null) {
-          playerObject.cape.visible = false
-        }
+    this.updateNameTagVisibility(e)
+
+    if (entity.type === 'player' && e.playerObject && entity.equipment) {
+      const { playerObject } = e
+      playerObject.backEquipment = entity.equipment.some((item) => item?.name === 'elytra') ? 'elytra' : 'cape'
+      if (playerObject.cape.map === null) {
+        playerObject.cape.visible = false
       }
     }
 
@@ -1116,18 +1116,17 @@ export class Entities {
   }
 
   updateNameTagVisibility (entity: SceneEntity) {
-    if (entity.playerObject && entity.username) {
-      const entityTeam = bot.teamMap[entity.username]
-      const nameTagVisibility = entityTeam?.nameTagVisibility || 'always'
-      const showNameTag = nameTagVisibility === 'always' ||
-        (nameTagVisibility === 'hideForOwnTeam' && entityTeam !== bot.teamMap[bot.username]) ||
-        (nameTagVisibility === 'hideForOtherTeams' && (entityTeam === bot.teamMap[bot.username] || bot.teamMap[bot.username] === undefined))
-      entity.traverse(c => {
-        if (c.name === 'nametag') {
-          c.visible = showNameTag
-        }
-      })
-    }
+    const playerTeam = this.worldRenderer.playerStateReactive.team
+    const entityTeam = entity.originalEntity.team
+    const nameTagVisibility = entityTeam?.nameTagVisibility || 'always'
+    const showNameTag = nameTagVisibility === 'always' ||
+      (nameTagVisibility === 'hideForOwnTeam' && entityTeam?.team !== playerTeam?.team) ||
+      (nameTagVisibility === 'hideForOtherTeams' && (entityTeam?.team === playerTeam?.team || playerTeam === undefined))
+    entity.traverse(c => {
+      if (c.name === 'nametag') {
+        c.visible = showNameTag
+      }
+    })
   }
 
   addMapModel (entityMesh: THREE.Object3D, mapNumber: number, rotation: number) {

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -189,23 +189,54 @@ customEvents.on('gameLoaded', () => {
 
   })
 
-  // Update team nametag display for players
-  const updateTeamMembers = (team: Team) => {
+  const updateAllEntitiesInTeams = () => {
     for (const entity of Object.values(bot.entities)) {
-      if (entity.type === 'player' && entity.username && team.members.includes(entity.username)) {
+      if (entity.type === 'player' && entity.username && bot.teamMap[entity.username] || entity.uuid && bot.teamMap[entity.uuid]) {
         bot.emit('entityUpdate', entity)
       }
     }
   }
 
-  bot.on('teamUpdated', updateTeamMembers)
-  bot.on('teamMemberAdded', updateTeamMembers)
+  bot.on('teamUpdated', (team: Team) => {
+    if (appViewer.playerState.reactive.team?.team === team.team) {
+      // Player team was updated, need to update all entities that are in a team
+      updateAllEntitiesInTeams()
+    } else {
+      for (const entity of Object.values(bot.entities)) {
+        if (entity.type === 'player' && entity.username && team.members.includes(entity.username) || entity.uuid && team.members.includes(entity.uuid)) {
+          bot.emit('entityUpdate', entity)
+        }
+      }
+    }
+  })
 
-  bot.on('teamMemberRemoved', () => {
-    // Need to update all players as we don't know which player was removed
-    for (const entity of Object.values(bot.entities)) {
-      if (entity.type === 'player') {
-        bot.emit('entityUpdate', entity)
+  bot.on('teamMemberAdded', (team: Team) => {
+    if (appViewer.playerState.reactive.team?.team !== team.team && team.members.includes(bot.username)) {
+      appViewer.playerState.reactive.team = team
+      // Player was added to a team, need to update all entities that are in a team
+      updateAllEntitiesInTeams()
+    } else {
+      // Need to update all entities that are in a team as we don't know which was added
+      for (const entity of Object.values(bot.entities)) {
+        if (entity.type === 'player' && entity.username && team.members.includes(entity.username) || entity.uuid && team.members.includes(entity.uuid)) {
+          bot.emit('entityUpdate', entity)
+        }
+      }
+    }
+  })
+
+  bot.on('teamMemberRemoved', (team: Team) => {
+    if (appViewer.playerState.reactive.team?.team === team.team && !team.members.includes(bot.username)) {
+      appViewer.playerState.reactive.team = undefined
+      // Player was removed from a team, need to update all entities that are in a team
+      updateAllEntitiesInTeams()
+    } else {
+      // Need to update all entities that are not in a team as we don't know which were removed
+      for (const entity of Object.values(bot.entities)) {
+        const entityTeam = entity.type === 'player' && entity.username ? bot.teamMap[entity.username] : entity.uuid ? bot.teamMap[entity.uuid] : undefined
+        if (!entityTeam) {
+          bot.emit('entityUpdate', entity)
+        }
       }
     }
   })

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -189,33 +189,36 @@ customEvents.on('gameLoaded', () => {
 
   })
 
-  const updateAllEntitiesInTeams = () => {
+  bot.on('teamUpdated', (team: Team) => {
     for (const entity of Object.values(bot.entities)) {
-      if (entity.type === 'player' && entity.username && bot.teamMap[entity.username] || entity.uuid && bot.teamMap[entity.uuid]) {
+      if (entity.type === 'player' && entity.username && team.members.includes(entity.username) || entity.uuid && team.members.includes(entity.uuid)) {
+        bot.emit('entityUpdate', entity)
+      }
+    }
+  })
+
+  const updateEntityNameTags = (team: Team) => {
+    for (const entity of Object.values(bot.entities)) {
+      const entityTeam = entity.type === 'player' && entity.username ? bot.teamMap[entity.username] : entity.uuid ? bot.teamMap[entity.uuid] : undefined
+      if ((entityTeam?.nameTagVisibility === 'hideForOwnTeam' && entityTeam.name === team.name)
+        || (entityTeam?.nameTagVisibility === 'hideForOtherTeams' && entityTeam.name !== team.name)) {
         bot.emit('entityUpdate', entity)
       }
     }
   }
 
-  bot.on('teamUpdated', (team: Team) => {
-    if (appViewer.playerState.reactive.team?.team === team.team) {
-      // Player team was updated, need to update all entities that are in a team
-      updateAllEntitiesInTeams()
-    } else {
-      for (const entity of Object.values(bot.entities)) {
-        if (entity.type === 'player' && entity.username && team.members.includes(entity.username) || entity.uuid && team.members.includes(entity.uuid)) {
-          bot.emit('entityUpdate', entity)
-        }
-      }
-    }
-  })
+  const doEntitiesNeedUpdating = (team: Team) => {
+    return team.nameTagVisibility === 'never'
+      || (team.nameTagVisibility === 'hideForOtherTeams' && appViewer.playerState.reactive.team?.team !== team.team)
+      || (team.nameTagVisibility === 'hideForOwnTeam' && appViewer.playerState.reactive.team?.team === team.team)
+  }
 
   bot.on('teamMemberAdded', (team: Team, members: string[]) => {
     if (members.includes(bot.username) && appViewer.playerState.reactive.team?.team !== team.team) {
       appViewer.playerState.reactive.team = team
-      // Player was added to a team, need to update all entities that are in a team
-      updateAllEntitiesInTeams()
-    } else {
+      // Player was added to a team, need to check if any entities need updating
+      updateEntityNameTags(team)
+    } else if (doEntitiesNeedUpdating(team)) {
       // Need to update all entities that were added
       for (const entity of Object.values(bot.entities)) {
         if (entity.type === 'player' && entity.username && members.includes(entity.username) || entity.uuid && members.includes(entity.uuid)) {
@@ -228,15 +231,23 @@ customEvents.on('gameLoaded', () => {
   bot.on('teamMemberRemoved', (team: Team, members: string[]) => {
     if (members.includes(bot.username) && appViewer.playerState.reactive.team?.team === team.team) {
       appViewer.playerState.reactive.team = undefined
-      // Player was removed from a team, need to update all entities that are in a team
-      updateAllEntitiesInTeams()
-    } else {
+      // Player was removed from a team, need to check if any entities need updating
+      updateEntityNameTags(team)
+    } else if (doEntitiesNeedUpdating(team)) {
       // Need to update all entities that were removed
       for (const entity of Object.values(bot.entities)) {
         if (entity.type === 'player' && entity.username && members.includes(entity.username) || entity.uuid && members.includes(entity.uuid)) {
           bot.emit('entityUpdate', entity)
         }
       }
+    }
+  })
+
+  bot.on('teamRemoved', (team: Team) => {
+    if (appViewer.playerState.reactive.team?.team === team.team) {
+      appViewer.playerState.reactive.team = undefined
+      // Player's team was removed, need to update all entities that are in a team
+      updateEntityNameTags(team)
     }
   })
 

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -4,6 +4,7 @@ import tracker from '@nxg-org/mineflayer-tracker'
 import { loader as autoJumpPlugin } from '@nxg-org/mineflayer-auto-jump'
 import { subscribeKey } from 'valtio/utils'
 import { getThreeJsRendererMethods } from 'renderer/viewer/three/threeJsMethods'
+import { Team } from 'mineflayer'
 import { options, watchValue } from './optionsStorage'
 import { miscUiState } from './globalState'
 import { EntityStatus } from './mineflayer/entityStatus'
@@ -187,4 +188,26 @@ customEvents.on('gameLoaded', () => {
     }
 
   })
+
+  // Update team nametag display for players
+  const updateTeamMembers = (team: Team) => {
+    for (const entity of Object.values(bot.entities)) {
+      if (entity.type === 'player' && entity.username && team.members.includes(entity.username)) {
+        bot.emit('entityUpdate', entity)
+      }
+    }
+  }
+
+  bot.on('teamUpdated', updateTeamMembers)
+  bot.on('teamMemberAdded', updateTeamMembers)
+
+  bot.on('teamMemberRemoved', () => {
+    // Need to update all players as we don't know which player was removed
+    for (const entity of Object.values(bot.entities)) {
+      if (entity.type === 'player') {
+        bot.emit('entityUpdate', entity)
+      }
+    }
+  })
+
 })

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -210,31 +210,30 @@ customEvents.on('gameLoaded', () => {
     }
   })
 
-  bot.on('teamMemberAdded', (team: Team) => {
-    if (appViewer.playerState.reactive.team?.team !== team.team && team.members.includes(bot.username)) {
+  bot.on('teamMemberAdded', (team: Team, members: string[]) => {
+    if (members.includes(bot.username) && appViewer.playerState.reactive.team?.team !== team.team) {
       appViewer.playerState.reactive.team = team
       // Player was added to a team, need to update all entities that are in a team
       updateAllEntitiesInTeams()
     } else {
-      // Need to update all entities that are in a team as we don't know which was added
+      // Need to update all entities that were added
       for (const entity of Object.values(bot.entities)) {
-        if (entity.type === 'player' && entity.username && team.members.includes(entity.username) || entity.uuid && team.members.includes(entity.uuid)) {
+        if (entity.type === 'player' && entity.username && members.includes(entity.username) || entity.uuid && members.includes(entity.uuid)) {
           bot.emit('entityUpdate', entity)
         }
       }
     }
   })
 
-  bot.on('teamMemberRemoved', (team: Team) => {
-    if (appViewer.playerState.reactive.team?.team === team.team && !team.members.includes(bot.username)) {
+  bot.on('teamMemberRemoved', (team: Team, members: string[]) => {
+    if (members.includes(bot.username) && appViewer.playerState.reactive.team?.team === team.team) {
       appViewer.playerState.reactive.team = undefined
       // Player was removed from a team, need to update all entities that are in a team
       updateAllEntitiesInTeams()
     } else {
-      // Need to update all entities that are not in a team as we don't know which were removed
+      // Need to update all entities that were removed
       for (const entity of Object.values(bot.entities)) {
-        const entityTeam = entity.type === 'player' && entity.username ? bot.teamMap[entity.username] : entity.uuid ? bot.teamMap[entity.uuid] : undefined
-        if (!entityTeam) {
+        if (entity.type === 'player' && entity.username && members.includes(entity.username) || entity.uuid && members.includes(entity.uuid)) {
           bot.emit('entityUpdate', entity)
         }
       }

--- a/src/mineflayer/playerState.ts
+++ b/src/mineflayer/playerState.ts
@@ -99,6 +99,10 @@ export class PlayerStateControllerMain {
     })
     this.reactive.gameMode = bot.game?.gameMode
 
+    customEvents.on('gameLoaded', () => {
+      this.reactive.team = bot.teamMap[bot.username]
+    })
+
     this.watchReactive()
   }
 


### PR DESCRIPTION
This adds support for the `nameTagVisibility` option which teams have to hide the names of players in certain situations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Name tags for player entities are now explicitly managed and displayed based on team visibility settings.
  - Player name tags update dynamically when team membership changes.
  - Player team affiliation is now tracked and reflected in entity displays and player state.

- **Bug Fixes**
  - Ensured name tag visibility is always updated, preventing outdated or incorrect display when teams change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->