### PR TITLE
feat: Config option to proxy skin textures

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
   "defaultHost": "<from-proxy>",
   "defaultProxy": "https://proxy.mcraft.fun",
   "mapsProvider": "https://maps.mcraft.fun/",
+  "skinTexturesProxy": "",
   "peerJsServer": "",
   "peerJsServerFallback": "https://p2p.mcraft.fun",
   "promoteServers": [

--- a/renderer/viewer/lib/worldrendererCommon.ts
+++ b/renderer/viewer/lib/worldrendererCommon.ts
@@ -36,6 +36,7 @@ export const defaultWorldRendererConfig = {
   mesherWorkers: 4,
   isPlayground: false,
   renderEars: true,
+  skinTexturesProxy: undefined as string | undefined,
   // game renderer setting actually
   showHand: false,
   viewBobbing: false,

--- a/renderer/viewer/three/entities.ts
+++ b/renderer/viewer/three/entities.ts
@@ -1404,6 +1404,11 @@ function addArmorModel (worldRenderer: WorldRendererThree, entityMesh: THREE.Obj
         if (textureData) {
           const decodedData = JSON.parse(Buffer.from(textureData, 'base64').toString())
           texturePath = decodedData.textures?.SKIN?.url
+          const { skinTexturesProxy } = this.worldRenderer.worldRendererConfig
+          if (skinTexturesProxy) {
+            texturePath = texturePath?.replace('http://textures.minecraft.net/', skinTexturesProxy)
+              .replace('https://textures.minecraft.net/', skinTexturesProxy)
+          }
         }
       } catch (err) {
         console.error('Error decoding player head texture:', err)

--- a/renderer/viewer/three/worldrendererThree.ts
+++ b/renderer/viewer/three/worldrendererThree.ts
@@ -755,7 +755,12 @@ export class WorldRendererThree extends WorldRendererCommon {
 
     try {
       const textureData = JSON.parse(Buffer.from(textures.Value, 'base64').toString())
-      const skinUrl = textureData.textures?.SKIN?.url
+      let skinUrl = textureData.textures?.SKIN?.url
+      const { skinTexturesProxy } = this.worldRendererConfig
+      if (skinTexturesProxy) {
+        skinUrl = skinUrl?.replace('http://textures.minecraft.net/', skinTexturesProxy)
+          .replace('https://textures.minecraft.net/', skinTexturesProxy)
+      }
 
       const mesh = getMesh(this, skinUrl, armorModel.head)
       const group = new THREE.Group()

--- a/src/appConfig.ts
+++ b/src/appConfig.ts
@@ -54,6 +54,7 @@ export type AppConfig = {
   supportedLanguages?: string[]
   showModsButton?: boolean
   defaultUsername?: string
+  skinTexturesProxy?: string
 }
 
 export const loadAppConfig = (appConfig: AppConfig) => {
@@ -81,6 +82,8 @@ export const loadAppConfig = (appConfig: AppConfig) => {
     Object.assign(customKeymaps, defaultsDeep(appConfig.keybindings, customKeymaps))
     updateBinds(customKeymaps)
   }
+
+  appViewer.inWorldRenderingConfig.skinTexturesProxy = appConfig.skinTexturesProxy
 
   setStorageDataOnAppConfigLoad(appConfig)
 }

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -199,6 +199,15 @@ customEvents.on('gameLoaded', () => {
 
   // Texture override from packet properties
   bot._client.on('player_info', (packet) => {
+    const applySkinTexturesProxy = (url: string) => {
+      const { appConfig } = miscUiState
+      if (appConfig?.skinTexturesProxy) {
+        return url?.replace('http://textures.minecraft.net/', appConfig.skinTexturesProxy)
+          .replace('https://textures.minecraft.net/', appConfig.skinTexturesProxy)
+      }
+      return url
+    }
+
     for (const playerEntry of packet.data) {
       if (!playerEntry.player && !playerEntry.properties) continue
       let textureProperty = playerEntry.properties?.find(prop => prop?.name === 'textures')
@@ -208,8 +217,8 @@ customEvents.on('gameLoaded', () => {
       if (textureProperty) {
         try {
           const textureData = JSON.parse(Buffer.from(textureProperty.value, 'base64').toString())
-          const skinUrl = textureData.textures?.SKIN?.url
-          const capeUrl = textureData.textures?.CAPE?.url
+          const skinUrl = applySkinTexturesProxy(textureData.textures?.SKIN?.url)
+          const capeUrl = applySkinTexturesProxy(textureData.textures?.CAPE?.url)
 
           // Find entity with matching UUID and update skin
           let entityId = ''


### PR DESCRIPTION
This adds an option `skinTexturesProxy` to the config.json which allows providing an own proxy to stop loading textures for skins ans skulls from textures.minecraft.net directly. This might be necessary because either too many requests are done from the same IP and the skins want to be cached or Mojang decides that a certain browser is not allowed to load images cross-origin on a website anymore (I've seen both being an issue)

This kinda relies on https://github.com/zardoy/mc-assets/pull/12 to fully work in the case where the proxy's domain is not the same as where the webclient is hosted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a custom proxy URL for loading Minecraft skin textures. If configured, all skin and cape texture requests will be redirected through the provided proxy instead of the official servers.

* **Configuration**
  * Introduced a new optional configuration setting for the skin textures proxy URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->