### PR TITLE
fix: skin from textures property would not show

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,7 +136,7 @@ importers:
         version: 4.17.21
       mcraft-fun-mineflayer:
         specifier: ^0.1.23
-        version: 0.1.23(encoding@0.1.13)(mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/1616261f727398d0b14359262726828d24797fcc(encoding@0.1.13))
+        version: 0.1.23(encoding@0.1.13)(mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/3daf1f4bdc6afad0dedd87b879875f3dbb7b0980(encoding@0.1.13))
       minecraft-data:
         specifier: 3.92.0
         version: 3.92.0
@@ -341,7 +341,7 @@ importers:
         version: https://codeload.github.com/zardoy/minecraft-inventory-gui/tar.gz/89c33d396f3fde4804c71f4be3c203ade1833b41(@types/react@18.3.18)(react@18.3.1)
       mineflayer:
         specifier: github:zardoy/mineflayer#gen-the-master
-        version: https://codeload.github.com/zardoy/mineflayer/tar.gz/1616261f727398d0b14359262726828d24797fcc(encoding@0.1.13)
+        version: https://codeload.github.com/zardoy/mineflayer/tar.gz/3daf1f4bdc6afad0dedd87b879875f3dbb7b0980(encoding@0.1.13)
       mineflayer-mouse:
         specifier: ^0.1.11
         version: 0.1.11
@@ -6678,8 +6678,8 @@ packages:
     resolution: {integrity: sha512-GtW4hkijyZbSu5LKYYD89xZu+XY7OoP7IkrCnNEn6EdPm0+vr2THoJgFGKrlze9/81+T+P3E4qvJXNFiU/zeJg==}
     engines: {node: '>=22'}
 
-  mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/1616261f727398d0b14359262726828d24797fcc:
-    resolution: {tarball: https://codeload.github.com/zardoy/mineflayer/tar.gz/1616261f727398d0b14359262726828d24797fcc}
+  mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/3daf1f4bdc6afad0dedd87b879875f3dbb7b0980:
+    resolution: {tarball: https://codeload.github.com/zardoy/mineflayer/tar.gz/3daf1f4bdc6afad0dedd87b879875f3dbb7b0980}
     version: 4.30.0
     engines: {node: '>=22'}
 
@@ -16956,12 +16956,12 @@ snapshots:
       maxrects-packer: '@zardoy/maxrects-packer@2.7.4'
       zod: 3.24.2
 
-  mcraft-fun-mineflayer@0.1.23(encoding@0.1.13)(mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/1616261f727398d0b14359262726828d24797fcc(encoding@0.1.13)):
+  mcraft-fun-mineflayer@0.1.23(encoding@0.1.13)(mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/3daf1f4bdc6afad0dedd87b879875f3dbb7b0980(encoding@0.1.13)):
     dependencies:
       '@zardoy/flying-squid': 0.0.49(encoding@0.1.13)
       exit-hook: 2.2.1
       minecraft-protocol: https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/6c2204a813690ead420e2b8c7f0ef32ca357d176(patch_hash=a8726e6981ddc3486262d981d1e2030f379901c055ac9c4bf3036b4149e860e0)(encoding@0.1.13)
-      mineflayer: https://codeload.github.com/zardoy/mineflayer/tar.gz/1616261f727398d0b14359262726828d24797fcc(encoding@0.1.13)
+      mineflayer: https://codeload.github.com/zardoy/mineflayer/tar.gz/3daf1f4bdc6afad0dedd87b879875f3dbb7b0980(encoding@0.1.13)
       prismarine-item: 1.16.0
       ws: 8.18.1
     transitivePeerDependencies:
@@ -17379,7 +17379,7 @@ snapshots:
       - encoding
       - supports-color
 
-  mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/1616261f727398d0b14359262726828d24797fcc(encoding@0.1.13):
+  mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/3daf1f4bdc6afad0dedd87b879875f3dbb7b0980(encoding@0.1.13):
     dependencies:
       '@nxg-org/mineflayer-physics-util': 1.8.10
       minecraft-data: 3.92.0

--- a/renderer/viewer/three/entities.ts
+++ b/renderer/viewer/three/entities.ts
@@ -486,6 +486,7 @@ export class Entities {
       .some(channel => channel !== 0)
   }
 
+  // todo true/undefined doesnt reset the skin to the default one
   // eslint-disable-next-line max-params
   async updatePlayerSkin (entityId: string | number, username: string | undefined, uuidCache: string | undefined, skinUrl: string | true, capeUrl: string | true | undefined = undefined) {
     if (uuidCache) {

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -198,7 +198,7 @@ customEvents.on('gameLoaded', () => {
     }
   })
 
-  const applySkinTexturesProxy = (url: string) => {
+  const applySkinTexturesProxy = (url: string | undefined) => {
     const { appConfig } = miscUiState
     if (appConfig?.skinTexturesProxy) {
       return url?.replace('http://textures.minecraft.net/', appConfig.skinTexturesProxy)

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -208,12 +208,12 @@ customEvents.on('gameLoaded', () => {
   }
 
   // Texture override from packet properties
-  const updateSkin = (player: { username, uuid, skinData }) => {
+  const updateSkin = (player: import('mineflayer').Player) => {
     if (!player.uuid || !player.username || !player.skinData) return
 
     try {
       const skinUrl = applySkinTexturesProxy(player.skinData.url)
-      const capeUrl = applySkinTexturesProxy(player.skinData.capeUrl)
+      const capeUrl = applySkinTexturesProxy((player.skinData as any).capeUrl)
 
       // Find entity with matching UUID and update skin
       let entityId = ''
@@ -224,7 +224,7 @@ customEvents.on('gameLoaded', () => {
         }
       }
       // even if not found, still record to cache
-      void getThreeJsRendererMethods()?.updatePlayerSkin(entityId, player.username, player.uuid, skinUrl, capeUrl)
+      void getThreeJsRendererMethods()?.updatePlayerSkin(entityId, player.username, player.uuid, skinUrl ?? true, capeUrl)
     } catch (err) {
       console.error('Error decoding player texture:', err)
     }

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -213,7 +213,7 @@ customEvents.on('gameLoaded', () => {
       if (!playerEntry.player && !playerEntry.properties) continue
       let textureProperty = playerEntry.properties?.find(prop => prop?.name === 'textures')
       if (!textureProperty) {
-        textureProperty = playerEntry.player?.properties?.find(prop => prop?.key === 'textures')
+        textureProperty = playerEntry.player?.properties?.find(prop => prop?.name === 'textures')
       }
       if (textureProperty) {
         try {

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -198,46 +198,40 @@ customEvents.on('gameLoaded', () => {
     }
   })
 
-  // Texture override from packet properties
-  bot._client.on('player_info', (packet) => {
-    const applySkinTexturesProxy = (url: string) => {
-      const { appConfig } = miscUiState
-      if (appConfig?.skinTexturesProxy) {
-        return url?.replace('http://textures.minecraft.net/', appConfig.skinTexturesProxy)
-          .replace('https://textures.minecraft.net/', appConfig.skinTexturesProxy)
-      }
-      return url
+  const applySkinTexturesProxy = (url: string) => {
+    const { appConfig } = miscUiState
+    if (appConfig?.skinTexturesProxy) {
+      return url?.replace('http://textures.minecraft.net/', appConfig.skinTexturesProxy)
+        .replace('https://textures.minecraft.net/', appConfig.skinTexturesProxy)
     }
+    return url
+  }
 
-    for (const playerEntry of packet.data) {
-      if (!playerEntry.player && !playerEntry.properties) continue
-      let textureProperty = playerEntry.properties?.find(prop => prop?.name === 'textures')
-      if (!textureProperty) {
-        textureProperty = playerEntry.player?.properties?.find(prop => prop?.name === 'textures')
-      }
-      if (textureProperty) {
-        try {
-          const textureData = JSON.parse(Buffer.from(textureProperty.value, 'base64').toString())
-          const skinUrl = applySkinTexturesProxy(textureData.textures?.SKIN?.url)
-          const capeUrl = applySkinTexturesProxy(textureData.textures?.CAPE?.url)
+  // Texture override from packet properties
+  const updateSkin = (player: { username, uuid, skinData }) => {
+    if (!player.uuid || !player.username || !player.skinData) return
 
-          // Find entity with matching UUID and update skin
-          let entityId = ''
-          for (const [entId, entity] of Object.entries(bot.entities)) {
-            if (entity.uuid === playerEntry.uuid) {
-              entityId = entId
-              break
-            }
-          }
-          // even if not found, still record to cache
-          void getThreeJsRendererMethods()?.updatePlayerSkin(entityId, playerEntry.player?.name, playerEntry.uuid, skinUrl, capeUrl)
-        } catch (err) {
-          console.error('Error decoding player texture:', err)
+    try {
+      const skinUrl = applySkinTexturesProxy(player.skinData.url)
+      const capeUrl = applySkinTexturesProxy(player.skinData.capeUrl)
+
+      // Find entity with matching UUID and update skin
+      let entityId = ''
+      for (const [entId, entity] of Object.entries(bot.entities)) {
+        if (entity.uuid === player.uuid) {
+          entityId = entId
+          break
         }
       }
+      // even if not found, still record to cache
+      void getThreeJsRendererMethods()?.updatePlayerSkin(entityId, player.username, player.uuid, skinUrl, capeUrl)
+    } catch (err) {
+      console.error('Error decoding player texture:', err)
     }
+  }
 
-  })
+  bot.on('playerJoined', updateSkin)
+  bot.on('playerUpdated', updateSkin)
 
   bot.on('teamUpdated', (team: Team) => {
     for (const entity of Object.values(bot.entities)) {


### PR DESCRIPTION
Fix for the skins not working on modern versions. I think this changed from a mineflayer update? Because I'm sure that find with the `prop?.key` worked before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved player skin texture updates for more reliable and consistent display when players join or update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->