### PR TITLE
fix: Effects and Game Indicators overlay toggles didn't work

### DIFF
--- a/src/react/IndicatorEffectsProvider.tsx
+++ b/src/react/IndicatorEffectsProvider.tsx
@@ -118,9 +118,9 @@ export default ({ displayEffects = true, displayIndicators = true }: { displayEf
   }, [])
 
   return <IndicatorEffects
-    indicators={displayIndicators ? allIndicators : defaultIndicatorsState}
-    effects={displayEffects ? effects : []}
-    displayIndicators
-    displayEffects
+    indicators={allIndicators}
+    effects={effects}
+    displayIndicators={displayIndicators}
+    displayEffects={displayEffects}
   />
 }

--- a/src/react/IndicatorEffectsProvider.tsx
+++ b/src/react/IndicatorEffectsProvider.tsx
@@ -5,7 +5,6 @@ import { Effect } from 'mineflayer'
 import { inGameError } from '../utils'
 import { fsState } from '../loadSave'
 import { gameAdditionalState, miscUiState } from '../globalState'
-import { options } from '../optionsStorage'
 import IndicatorEffects, { EffectType, defaultIndicatorsState } from './IndicatorEffects'
 import { images } from './effectsImages'
 
@@ -67,7 +66,6 @@ export default ({ displayEffects = true, displayIndicators = true }: { displayEf
   const { mesherWork } = useSnapshot(appViewer.rendererState).world
 
   const { hasErrors } = useSnapshot(miscUiState)
-  const { disabledUiParts } = useSnapshot(options)
   const { isReadonly, openReadOperations, openWriteOperations } = useSnapshot(fsState)
   const { noConnection, poorConnection } = useSnapshot(gameAdditionalState)
   const allIndicators: typeof defaultIndicatorsState = {
@@ -120,8 +118,8 @@ export default ({ displayEffects = true, displayIndicators = true }: { displayEf
   }, [])
 
   return <IndicatorEffects
-    indicators={allIndicators}
-    effects={effects}
+    indicators={displayIndicators ? allIndicators : defaultIndicatorsState}
+    effects={displayEffects ? effects : []}
     displayIndicators
     displayEffects
   />


### PR DESCRIPTION
This fixes that disabling the effects and game indicators overlays wasn't working via the config gui or `disabledUiParts` query parameters as the passed boolean parameters were never used in the `IndicatorEffectsProvider.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved conditional rendering of indicators and effects based on input props.
  * Removed dependency on internal options state for determining UI display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->