### PR TITLE
Add server-side logging

### DIFF
--- a/src/appParams.ts
+++ b/src/appParams.ts
@@ -9,6 +9,7 @@ export type AppQsParams = {
   name?: string
   version?: string
   proxy?: string
+  proxyLogging?: string
   username?: string
   lockConnect?: string
   autoConnect?: string

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -8,6 +8,7 @@ declare const bot: Omit<import('mineflayer').Bot, 'world' | '_client'> & {
   _client: Omit<import('minecraft-protocol').Client, 'on'> & {
     write: typeof import('./generatedClientPackets').clientWrite
     on: typeof import('./generatedServerPackets').clientOn
+    logProxy: (msg: string) => void
   }
 }
 declare const __type_bot: typeof bot

--- a/src/index.ts
+++ b/src/index.ts
@@ -265,6 +265,7 @@ export async function connect (connectOptions: ConnectOptions) {
     }
 
     setLoadingScreenStatus(`Error encountered. ${err}`, true)
+    bot._client.logProxy(`Error encountered: ${JSON.stringify(err, null, 2)}`)
     appStatusState.showReconnect = true
     onPossibleErrorDisconnect()
     destroyAll()
@@ -578,6 +579,7 @@ export async function connect (connectOptions: ConnectOptions) {
       'mapDownloader-saveToFile': false,
       // "mapDownloader-saveInternal": false, // do not save into memory, todo must be implemeneted as we do really care of ram
     }) as unknown as typeof __type_bot
+    bot._client.logProxy = appQueryParams.proxyLogging ? net['logProxy'] : () => { }
     window.bot = bot
 
     if (connectOptions.viewerWsConnect) {
@@ -615,6 +617,7 @@ export async function connect (connectOptions: ConnectOptions) {
         }
         bot._client.socket.on('connect', () => {
           console.log('Proxy WebSocket connection established')
+          bot._client.logProxy('Connected!')
           //@ts-expect-error
           bot._client.socket._ws.addEventListener('close', () => {
             console.log('WebSocket connection closed')
@@ -661,6 +664,7 @@ export async function connect (connectOptions: ConnectOptions) {
 
   bot.on('kicked', (kickReason) => {
     console.log('You were kicked!', kickReason)
+    bot._client.logProxy(`Got kicked with reason: ${JSON.stringify(kickReason)}`)
     const { formatted: kickReasonFormatted, plain: kickReasonString } = parseFormattedMessagePacket(kickReason)
     // close all modals
     for (const modal of activeModalStack) {
@@ -685,6 +689,7 @@ export async function connect (connectOptions: ConnectOptions) {
   bot.on('end', (endReason) => {
     if (ended) return
     console.log('disconnected for', endReason)
+    bot._client.logProxy(`Disconnected with end reason: ${JSON.stringify(endReason)}`)
     if (endReason === 'socketClosed') {
       endReason = lastKnownKickReason ?? 'Connection with proxy server lost'
     }
@@ -751,6 +756,7 @@ export async function connect (connectOptions: ConnectOptions) {
     void waitForChunksToLoad().then(() => {
       window.worldLoadTime = (Date.now() - loadWorldStart) / 1000
       console.log('All chunks done and ready! Time from renderer connect to ready', (Date.now() - loadWorldStart) / 1000, 's')
+      bot._client.logProxy(`Chunks loaded in ${(Date.now() - loadWorldStart) / 1000}s`)
       document.dispatchEvent(new Event('cypress-world-ready'))
     })
 


### PR DESCRIPTION
Enable proxy logging by passing `?proxyLogging=true` as url query parameter.

Any important message will be send to the proxy for logging.[^1]
Currently implemented *"important messages"* include:
- when the client started and finished loading
- disconnect messages (with reason)
- message from the error handler

[^1]: Logging needs to be enabled on the proxy too. Also https://github.com/zardoy/prismarinejs-net-browserify/pull/1 is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new query parameter to enable proxy logging.
  * Introduced enhanced logging for key connection events and errors when proxy logging is enabled.

* **Bug Fixes**
  * No bug fixes included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->