### PR TITLE
fix: adding support for newer skin profile data structure in player heads

### DIFF
--- a/renderer/viewer/three/worldrendererThree.ts
+++ b/renderer/viewer/three/worldrendererThree.ts
@@ -769,7 +769,7 @@ export class WorldRendererThree extends WorldRendererCommon {
   renderHead (position: Vec3, rotation: number, isWall: boolean, blockEntity) {
     let textureData: string
     if (blockEntity.SkullOwner) {
-      textureData = blockEntity.SkullOwner.Properties?.textures[0]?.Value
+      textureData = blockEntity.SkullOwner.Properties?.textures?.[0]?.Value
     } else {
       textureData = blockEntity.profile?.properties?.find(p => p.name === 'textures')?.value
     }

--- a/renderer/viewer/three/worldrendererThree.ts
+++ b/renderer/viewer/three/worldrendererThree.ts
@@ -767,12 +767,17 @@ export class WorldRendererThree extends WorldRendererCommon {
   }
 
   renderHead (position: Vec3, rotation: number, isWall: boolean, blockEntity) {
-    const textures = blockEntity.SkullOwner?.Properties?.textures[0]
-    if (!textures) return
+    let textureData: string
+    if (blockEntity.SkullOwner) {
+      textureData = blockEntity.SkullOwner.Properties?.textures[0]?.Value
+    } else {
+      textureData = blockEntity.profile?.properties?.find(p => p.name === 'textures')?.value
+    }
+    if (!textureData) return
 
     try {
-      const textureData = JSON.parse(Buffer.from(textures.Value, 'base64').toString())
-      let skinUrl = textureData.textures?.SKIN?.url
+      const decodedData = JSON.parse(Buffer.from(textureData, 'base64').toString())
+      let skinUrl = decodedData.textures?.SKIN?.url
       const { skinTexturesProxy } = this.worldRendererConfig
       if (skinTexturesProxy) {
         skinUrl = skinUrl?.replace('http://textures.minecraft.net/', skinTexturesProxy)


### PR DESCRIPTION
When a player head has a `data.profile.properties` rather than `data.SkullOwner.Properties` data structure, it weren't rendered with its skin texture.

This fixes it by implementing a check wheather `SkullOwner` exists. This was also done in a similar way here:
https://github.com/zardoy/minecraft-web-client/blob/9d54c70fb724884cd98782cdca093aef622095ba/renderer/viewer/three/entities.ts#L1407-L1412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of player head/skin rendering by supporting multiple texture sources in player profiles.
  * Added safe handling for missing or invalid texture data to prevent blank heads or crashes.
  * Fixed proxy rewriting to correctly handle both HTTP and HTTPS skin URLs, reducing failed texture downloads.
  * Enhanced error handling during head mesh creation for more stable rendering with varied profile formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->