### PR TITLE
feat: make arrows colorful and metadata

### DIFF
--- a/renderer/viewer/three/waypointSprite.ts
+++ b/renderer/viewer/three/waypointSprite.ts
@@ -132,14 +132,14 @@ export function createWaypointSprite (options: {
     canvas.height = size
     const ctx = canvas.getContext('2d')!
     ctx.clearRect(0, 0, size, size)
-    
+
     // Draw arrow shape
     ctx.beginPath()
     ctx.moveTo(size * 0.15, size * 0.5)
     ctx.lineTo(size * 0.85, size * 0.5)
     ctx.lineTo(size * 0.5, size * 0.15)
     ctx.closePath()
-    
+
     // Use waypoint color for arrow
     const colorHex = `#${color.toString(16).padStart(6, '0')}`
     ctx.lineWidth = 6
@@ -147,7 +147,7 @@ export function createWaypointSprite (options: {
     ctx.stroke()
     ctx.fillStyle = colorHex
     ctx.fill()
-    
+
     const texture = new THREE.CanvasTexture(canvas)
     const material = new THREE.SpriteMaterial({ map: texture, transparent: true, depthTest: false, depthWrite: false })
     arrowSprite = new THREE.Sprite(material)

--- a/renderer/viewer/three/waypointSprite.ts
+++ b/renderer/viewer/three/waypointSprite.ts
@@ -16,7 +16,7 @@ export const WAYPOINT_CONFIG = {
   CANVAS_SCALE: 2,
   ARROW: {
     enabledDefault: false,
-    pixelSize: 30,
+    pixelSize: 50,
     paddingPx: 50,
   },
 }
@@ -50,6 +50,7 @@ export function createWaypointSprite (options: {
   depthTest?: boolean,
   // Y offset in world units used by updateScaleWorld only (screen-pixel API ignores this)
   labelYOffset?: number,
+  metadata?: any,
 }): WaypointSprite {
   const color = options.color ?? 0xFF_00_00
   const depthTest = options.depthTest ?? false
@@ -131,16 +132,22 @@ export function createWaypointSprite (options: {
     canvas.height = size
     const ctx = canvas.getContext('2d')!
     ctx.clearRect(0, 0, size, size)
+    
+    // Draw arrow shape
     ctx.beginPath()
-    ctx.moveTo(size * 0.2, size * 0.5)
-    ctx.lineTo(size * 0.8, size * 0.5)
-    ctx.lineTo(size * 0.5, size * 0.2)
+    ctx.moveTo(size * 0.15, size * 0.5)
+    ctx.lineTo(size * 0.85, size * 0.5)
+    ctx.lineTo(size * 0.5, size * 0.15)
     ctx.closePath()
-    ctx.lineWidth = 4
+    
+    // Use waypoint color for arrow
+    const colorHex = `#${color.toString(16).padStart(6, '0')}`
+    ctx.lineWidth = 6
     ctx.strokeStyle = 'black'
     ctx.stroke()
-    ctx.fillStyle = 'white'
+    ctx.fillStyle = colorHex
     ctx.fill()
+    
     const texture = new THREE.CanvasTexture(canvas)
     const material = new THREE.SpriteMaterial({ map: texture, transparent: true, depthTest: false, depthWrite: false })
     arrowSprite = new THREE.Sprite(material)
@@ -168,6 +175,9 @@ export function createWaypointSprite (options: {
     if (!arrowEnabled) return true
     ensureArrow()
     if (!arrowSprite) return true
+
+    // Check if onlyLeftRight is enabled in metadata
+    const onlyLeftRight = options.metadata?.onlyLeftRight === true
 
     // Build camera basis using camera.up to respect custom orientations
     const forward = new THREE.Vector3()
@@ -210,6 +220,20 @@ export function createWaypointSprite (options: {
       } else {
         rx = 0
         ry = Math.sign(ry)
+      }
+    }
+
+    // Apply onlyLeftRight logic - restrict arrows to left/right edges only
+    if (onlyLeftRight) {
+      // Force the arrow to appear only on left or right edges
+      if (Math.abs(rx) > Math.abs(ry)) {
+        // Horizontal direction is dominant, keep it
+        ry = 0
+      } else {
+        // Vertical direction is dominant, but we want only left/right
+        // So choose left or right based on the sign of rx
+        rx = rx >= 0 ? 1 : -1
+        ry = 0
       }
     }
 

--- a/renderer/viewer/three/waypoints.ts
+++ b/renderer/viewer/three/waypoints.ts
@@ -17,6 +17,7 @@ interface WaypointOptions {
   color?: number
   label?: string
   minDistance?: number
+  metadata?: any
 }
 
 export class WaypointsRenderer {
@@ -71,13 +72,14 @@ export class WaypointsRenderer {
     this.removeWaypoint(id)
 
     const color = options.color ?? 0xFF_00_00
-    const { label } = options
+    const { label, metadata } = options
     const minDistance = options.minDistance ?? 0
 
     const sprite = createWaypointSprite({
       position: new THREE.Vector3(x, y, z),
       color,
       label: (label || id),
+      metadata,
     })
     sprite.enableOffscreenArrow(true)
     sprite.setArrowParent(this.waypointScene)

--- a/src/customChannels.ts
+++ b/src/customChannels.ts
@@ -82,15 +82,30 @@ const registerWaypointChannels = () => {
       {
         name: 'color',
         type: 'i32'
+      },
+      {
+        name: 'metadataJson',
+        type: ['pstring', { countType: 'i16' }]
       }
     ]
   ]
 
   registerChannel('minecraft-web-client:waypoint-add', packetStructure, (data) => {
+    // Parse metadata if provided
+    let metadata: any = {}
+    if (data.metadataJson && data.metadataJson.trim() !== '') {
+      try {
+        metadata = JSON.parse(data.metadataJson)
+      } catch (error) {
+        console.warn('Failed to parse waypoint metadataJson:', error)
+      }
+    }
+
     getThreeJsRendererMethods()?.addWaypoint(data.id, data.x, data.y, data.z, {
       minDistance: data.minDistance,
       label: data.label || undefined,
-      color: data.color || undefined
+      color: data.color || undefined,
+      metadata
     })
   })
 


### PR DESCRIPTION
Add `metadataJson` to waypoints to enable `onlyLeftRight` arrow positioning and enhance offscreen arrow visibility with increased size and waypoint-colored fill.

---
<a href="https://cursor.com/background-agent?bcId=bc-7345239d-7afe-4d51-b048-150efddfb112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7345239d-7afe-4d51-b048-150efddfb112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Waypoint arrows are larger, with a refined shape and thicker outline for clearer direction.
  * Arrow fill now matches the waypoint color instead of white.
  * Optional metadata can be attached to waypoints (including via incoming packets).
  * New metadata option to constrain off-screen arrows to left/right edges for clearer guidance.
  * Arrows start hidden until needed and render above other elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->