### PR TITLE
Add WebMC & WS changes

### DIFF
--- a/config.json
+++ b/config.json
@@ -11,6 +11,10 @@
       "ip": "wss://play.mcraft.fun"
     },
     {
+      "ip": "wss://play.webmc.fun",
+      "name": "WebMC"
+    },
+    {
       "ip": "wss://ws.fuchsmc.net"
     },
     {

--- a/src/appConfig.ts
+++ b/src/appConfig.ts
@@ -35,7 +35,7 @@ export type AppConfig = {
   // defaultVersion?: string
   peerJsServer?: string
   peerJsServerFallback?: string
-  promoteServers?: Array<{ ip, description, version? }>
+  promoteServers?: Array<{ ip, description, name?, version?, }>
   mapsProvider?: string
 
   appParams?: Record<string, any> // query string params

--- a/src/mineflayer/websocket-core.ts
+++ b/src/mineflayer/websocket-core.ts
@@ -17,10 +17,10 @@ class CustomDuplex extends Duplex {
 export const getWebsocketStream = async (host: string) => {
   const baseProtocol = host.startsWith('ws://') ? 'ws' : 'wss'
   const hostClean = host.replace('ws://', '').replace('wss://', '')
-  const hostURL = new URL(hostClean, host)
+  const hostURL = new URL(`${baseProtocol}://${hostClean}`)
   const hostParams = hostURL.searchParams
   hostParams.append("client_mcraft", "")
-  const ws = new WebSocket(`${baseProtocol}://${hostURL.hostname}${hostURL.pathname}?${hostParams.toString()}`)
+  const ws = new WebSocket(`${baseProtocol}://${hostURL.host}${hostURL.pathname}?${hostParams.toString()}`)
   const clientDuplex = new CustomDuplex(undefined, data => {
     ws.send(data)
   })

--- a/src/mineflayer/websocket-core.ts
+++ b/src/mineflayer/websocket-core.ts
@@ -15,9 +15,9 @@ class CustomDuplex extends Duplex {
 }
 
 export const getWebsocketStream = async (host: string) => {
-  const baseProtocol = location.protocol === 'https:' ? 'wss' : host.startsWith('ws://') ? 'ws' : 'wss'
+  const baseProtocol = host.startsWith('ws://') ? 'ws' : 'wss'
   const hostClean = host.replace('ws://', '').replace('wss://', '')
-  const ws = new WebSocket(`${baseProtocol}://${hostClean}`)
+  const ws = new WebSocket(`${baseProtocol}://${hostClean}?client_mcraft`)
   const clientDuplex = new CustomDuplex(undefined, data => {
     ws.send(data)
   })

--- a/src/mineflayer/websocket-core.ts
+++ b/src/mineflayer/websocket-core.ts
@@ -19,7 +19,7 @@ export const getWebsocketStream = async (host: string) => {
   const hostClean = host.replace('ws://', '').replace('wss://', '')
   const hostURL = new URL(`${baseProtocol}://${hostClean}`)
   const hostParams = hostURL.searchParams
-  hostParams.append("client_mcraft", "")
+  hostParams.append('client_mcraft', '')
   const ws = new WebSocket(`${baseProtocol}://${hostURL.host}${hostURL.pathname}?${hostParams.toString()}`)
   const clientDuplex = new CustomDuplex(undefined, data => {
     ws.send(data)

--- a/src/mineflayer/websocket-core.ts
+++ b/src/mineflayer/websocket-core.ts
@@ -17,7 +17,9 @@ class CustomDuplex extends Duplex {
 export const getWebsocketStream = async (host: string) => {
   const baseProtocol = host.startsWith('ws://') ? 'ws' : 'wss'
   const hostClean = host.replace('ws://', '').replace('wss://', '')
-  const ws = new WebSocket(`${baseProtocol}://${hostClean}?client_mcraft`)
+  const hostURL = new URL(hostClean, host)
+  hostURL.searchParams.append("client_mcraft", "")
+  const ws = new WebSocket(`${baseProtocol}://${hostClean}?${hostURL.searchParams.toString()}`)
   const clientDuplex = new CustomDuplex(undefined, data => {
     ws.send(data)
   })

--- a/src/mineflayer/websocket-core.ts
+++ b/src/mineflayer/websocket-core.ts
@@ -18,8 +18,9 @@ export const getWebsocketStream = async (host: string) => {
   const baseProtocol = host.startsWith('ws://') ? 'ws' : 'wss'
   const hostClean = host.replace('ws://', '').replace('wss://', '')
   const hostURL = new URL(hostClean, host)
-  hostURL.searchParams.append("client_mcraft", "")
-  const ws = new WebSocket(`${baseProtocol}://${hostClean}?${hostURL.searchParams.toString()}`)
+  const hostParams = hostURL.searchParams
+  hostParams.append("client_mcraft", "")
+  const ws = new WebSocket(`${baseProtocol}://${hostURL.hostname}${hostURL.pathname}?${hostParams.toString()}`)
   const clientDuplex = new CustomDuplex(undefined, data => {
     ws.send(data)
   })

--- a/src/react/AddServerOrConnect.tsx
+++ b/src/react/AddServerOrConnect.tsx
@@ -117,7 +117,7 @@ export default ({ onBack, onConfirm, title = 'Add a Server', initialData, parseQ
   }
 
   const displayConnectButton = qsParamIp
-  const serverExamples = ['example.com:25565', 'play.hypixel.net', 'ws://play.pcm.gg']
+  const serverExamples = ['example.com:25565', 'play.hypixel.net', 'ws://play.pcm.gg', 'wss://play.webmc.fun']
   // pick random example
   const example = serverExamples[Math.floor(Math.random() * serverExamples.length)]
 

--- a/src/react/ServersListProvider.tsx
+++ b/src/react/ServersListProvider.tsx
@@ -119,6 +119,7 @@ const Inner = ({ hidden, customServersList }: { hidden?: boolean, customServersL
     ...serversListProvided,
     ...(customServersList ? [] : (miscUiState.appConfig?.promoteServers ?? [])).map((server): StoreServerItem => ({
       ip: server.ip,
+      name: server.name,
       versionOverride: server.version,
       description: server.description,
       isRecommended: true
@@ -167,6 +168,7 @@ const Inner = ({ hidden, customServersList }: { hidden?: boolean, customServersL
                   console.log('pingResult.fullInfo.description', pingResult.fullInfo.description)
                   data = {
                     formattedText: pingResult.fullInfo.description,
+                    icon: pingResult.fullInfo.favicon,
                     textNameRight: `ws ${pingResult.latency}ms`,
                     textNameRightGrayed: `${pingResult.fullInfo.players?.online ?? '??'}/${pingResult.fullInfo.players?.max ?? '??'}`,
                     offline: false


### PR DESCRIPTION
Adds WebMC to the multiplayer server list, allows connecting to local servers for development, fixes icons on websocket servers, and allows servers to see if the client is mcraft or something else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “WebMC” to the promoted servers list.
  - Promoted servers now show a friendly name alongside the IP.
  - Server status cards can display server icons when available.
  - Added “wss://play.webmc.fun” to example server suggestions.

- **Chores**
  - Improved WebSocket connection URL construction and query-parameter handling for better compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->