### PR TITLE
Forbid problematic connection versions

### DIFF
--- a/src/supportedVersions.mjs
+++ b/src/supportedVersions.mjs
@@ -7,4 +7,18 @@ const versionsFromProtocol = Object.values(postNettyVersionsByProtocolVersion.pc
 
 export const notTestedVersions = '1.19.3 1.20 1.19.1 1.19 1.18.1 1.15.1 1.14.1'.split(' ')
 
-export default versionsFromProtocol.filter(x => x !== '1.7' && !x.startsWith('1.7.'))
+// Versions >= 1.21.7 are forbidden due to critical world display issues
+const FORBIDDEN_VERSION_THRESHOLD = '1.21.7'
+const versionToNumber = (ver) => {
+  const [x, y = '0', z = '0'] = ver.split('.')
+  return +`${x.padStart(2, '0')}${y.padStart(2, '0')}${z.padStart(2, '0')}`
+}
+
+const forbiddenVersionThresholdNum = versionToNumber(FORBIDDEN_VERSION_THRESHOLD)
+
+export default versionsFromProtocol.filter(x => {
+  if (x === '1.7' || x.startsWith('1.7.')) return false
+  // Filter out versions >= 1.21.7
+  const versionNum = versionToNumber(x)
+  return versionNum < forbiddenVersionThresholdNum
+})


### PR DESCRIPTION
Forbid connecting to and selecting Minecraft versions 1.21.7 and above due to critical world display issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-188fc537-ca9e-43e5-a7a3-04e15b3e6c64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-188fc537-ca9e-43e5-a7a3-04e15b3e6c64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Blocks connecting/selecting Minecraft versions >=1.21.7 (throws UserError) and excludes them from the supported versions list.
> 
> - **Connection/version selection**:
>   - Add `checkForbiddenVersion` (threshold `1.21.7`) and enforce it when determining `finalVersion` (direct `botVersion`, local replay version, auto-selected server version, viewer WS version), throwing `UserError` for forbidden versions.
>   - Import `versionToNumber` from `mc-assets/dist/utils` to compare versions.
> - **Supported versions list**:
>   - Update `src/supportedVersions.mjs` to filter out versions `>= 1.21.7` (keeping existing `1.7.x` exclusion).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43ed9d57d5ab5424e1af368ed94779a8f83ba98e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added runtime version validation to prevent use of Minecraft 1.21.7 and later, which causes world display issues. Users attempting to access with unsupported versions will receive an error message directing them to use 1.21.6 or earlier.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->