### PR TITLE
Waypoint visual scaling factor

### DIFF
--- a/renderer/viewer/three/waypointSprite.ts
+++ b/renderer/viewer/three/waypointSprite.ts
@@ -21,6 +21,8 @@ export const WAYPOINT_CONFIG = {
   },
   // Default visual scale factor (can be overridden globally or per-waypoint)
   DEFAULT_VISUAL_SCALE: 1.0,
+  // Default opacity (can be overridden globally or per-waypoint)
+  DEFAULT_OPACITY: 1.0,
 }
 
 export type WaypointSprite = {
@@ -54,21 +56,30 @@ export function createWaypointSprite (options: {
   labelYOffset?: number,
   metadata?: any,
   visualScale?: number,
+  opacity?: number,
 }): WaypointSprite {
   const color = options.color ?? 0xFF_00_00
   const depthTest = options.depthTest ?? false
   const labelYOffset = options.labelYOffset ?? 1.5
-  
+
   // Get visual scale from options, metadata, server metadata, or default
   // Priority: options.visualScale > metadata.visualScale > window.serverMetadata?.waypointVisualScale > DEFAULT
-  const visualScale = options.visualScale 
-    ?? options.metadata?.visualScale 
+  const visualScale = options.visualScale
+    ?? options.metadata?.visualScale
     ?? (typeof window !== 'undefined' ? (window as any).serverMetadata?.waypointVisualScale : undefined)
     ?? WAYPOINT_CONFIG.DEFAULT_VISUAL_SCALE
+
+  // Get opacity from options, metadata, server metadata, or default
+  // Priority: options.opacity > metadata.opacity > window.serverMetadata?.waypointOpacity > DEFAULT
+  const opacity = options.opacity
+    ?? options.metadata?.opacity
+    ?? (typeof window !== 'undefined' ? (window as any).serverMetadata?.waypointOpacity : undefined)
+    ?? WAYPOINT_CONFIG.DEFAULT_OPACITY
 
   // Build combined sprite
   const sprite = createCombinedSprite(color, options.label ?? '', '0m', depthTest, visualScale)
   sprite.renderOrder = 10
+  sprite.material.opacity = opacity
   let currentLabel = options.label ?? ''
 
   // Performance optimization: cache distance text to avoid unnecessary updates
@@ -169,7 +180,7 @@ export function createWaypointSprite (options: {
     ctx.fill()
 
     const texture = new THREE.CanvasTexture(canvas)
-    const material = new THREE.SpriteMaterial({ map: texture, transparent: true, depthTest: false, depthWrite: false })
+    const material = new THREE.SpriteMaterial({ map: texture, transparent: true, depthTest: false, depthWrite: false, opacity })
     arrowSprite = new THREE.Sprite(material)
     arrowSprite.renderOrder = 12
     arrowSprite.visible = false

--- a/renderer/viewer/three/waypointSprite.ts
+++ b/renderer/viewer/three/waypointSprite.ts
@@ -20,9 +20,9 @@ export const WAYPOINT_CONFIG = {
     paddingPx: 50,
   },
   // Default visual scale factor (can be overridden globally or per-waypoint)
-  DEFAULT_VISUAL_SCALE: 1.0,
+  DEFAULT_VISUAL_SCALE: 1,
   // Default opacity (can be overridden globally or per-waypoint)
-  DEFAULT_OPACITY: 1.0,
+  DEFAULT_OPACITY: 1,
 }
 
 export type WaypointSprite = {
@@ -66,14 +66,14 @@ export function createWaypointSprite (options: {
   // Priority: options.visualScale > metadata.visualScale > window.serverMetadata?.waypointVisualScale > DEFAULT
   const visualScale = options.visualScale
     ?? options.metadata?.visualScale
-    ?? (typeof window !== 'undefined' ? (window as any).serverMetadata?.waypointVisualScale : undefined)
+    ?? (typeof window === 'undefined' ? undefined : (window as any).serverMetadata?.waypointVisualScale)
     ?? WAYPOINT_CONFIG.DEFAULT_VISUAL_SCALE
 
   // Get opacity from options, metadata, server metadata, or default
   // Priority: options.opacity > metadata.opacity > window.serverMetadata?.waypointOpacity > DEFAULT
   const opacity = options.opacity
     ?? options.metadata?.opacity
-    ?? (typeof window !== 'undefined' ? (window as any).serverMetadata?.waypointOpacity : undefined)
+    ?? (typeof window === 'undefined' ? undefined : (window as any).serverMetadata?.waypointOpacity)
     ?? WAYPOINT_CONFIG.DEFAULT_OPACITY
 
   // Build combined sprite
@@ -364,7 +364,7 @@ export function createWaypointSprite (options: {
 }
 
 // Internal helpers
-function drawCombinedCanvas (color: number, id: string, distance: string, visualScale: number = 1.0): HTMLCanvasElement {
+function drawCombinedCanvas (color: number, id: string, distance: string, visualScale = 1): HTMLCanvasElement {
   const scale = WAYPOINT_CONFIG.CANVAS_SCALE * (globalThis.devicePixelRatio || 1)
   const size = WAYPOINT_CONFIG.CANVAS_SIZE * scale
   const canvas = document.createElement('canvas')
@@ -422,7 +422,7 @@ function drawCombinedCanvas (color: number, id: string, distance: string, visual
   return canvas
 }
 
-function createCombinedSprite (color: number, id: string, distance: string, depthTest: boolean, visualScale: number = 1.0): THREE.Sprite {
+function createCombinedSprite (color: number, id: string, distance: string, depthTest: boolean, visualScale = 1): THREE.Sprite {
   const canvas = drawCombinedCanvas(color, id, distance, visualScale)
   const texture = new THREE.CanvasTexture(canvas)
   texture.anisotropy = 1

--- a/src/customChannels.ts
+++ b/src/customChannels.ts
@@ -63,12 +63,25 @@ const registerConnectMetadataChannel = () => {
   ]
 
   bot._client.registerChannel(CHANNEL_NAME, packetStructure, true)
+  
+  // Send client metadata to server
   bot._client.writeChannel(CHANNEL_NAME, {
     metadata: JSON.stringify({
       version: process.env.RELEASE_TAG,
       build: process.env.BUILD_VERSION,
       ...window.serverMetadataConnect,
     })
+  })
+  
+  // Listen for server metadata
+  bot._client.on(CHANNEL_NAME as any, (data) => {
+    try {
+      const metadata = JSON.parse(data.metadata)
+      window.serverMetadata = metadata
+      console.debug('Received server metadata:', metadata)
+    } catch (error) {
+      console.warn('Failed to parse server metadata:', error)
+    }
   })
 }
 

--- a/src/customChannels.ts
+++ b/src/customChannels.ts
@@ -63,7 +63,7 @@ const registerConnectMetadataChannel = () => {
   ]
 
   bot._client.registerChannel(CHANNEL_NAME, packetStructure, true)
-  
+
   // Send client metadata to server
   bot._client.writeChannel(CHANNEL_NAME, {
     metadata: JSON.stringify({
@@ -72,7 +72,7 @@ const registerConnectMetadataChannel = () => {
       ...window.serverMetadataConnect,
     })
   })
-  
+
   // Listen for server metadata
   bot._client.on(CHANNEL_NAME as any, (data) => {
     try {


### PR DESCRIPTION
Add support for overriding waypoint visual sizes (dot, arrow, and text) from custom channels server metadata or per-waypoint metadata to allow for visual customization.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-a2aa2270-bec5-4757-8838-d9f3d20bf519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a2aa2270-bec5-4757-8838-d9f3d20bf519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Waypoints now support configurable visual scale and opacity — marker size, label, distance text, borders and arrow sizing respect a user-adjustable visual scale and opacity.
  * Added default visual scale and opacity settings for consistent appearance out-of-the-box.
  * Client now exchanges metadata with the server on connect, enabling richer server-driven configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->