### PR TITLE
fix creative inventory mgmt set_slot timeouts on creative mode servers

### DIFF
--- a/renderer/viewer/sign-renderer/index.ts
+++ b/renderer/viewer/sign-renderer/index.ts
@@ -135,7 +135,10 @@ export const renderComponent = (
   const textWidths: number[] = []
 
   const renderText = (component: Message, parentFormatting?: Formatting | undefined) => {
-    const { text } = component
+    if (component.text != null && typeof component.text !== 'string') {
+      console.warn('renderText received non-string text value:', typeof component.text, component.text)
+    }
+    const text = component.text != null ? String(component.text) : undefined
     const formatting = {
       color: component.color ?? parentFormatting?.color,
       underlined: component.underlined ?? parentFormatting?.underlined,

--- a/renderer/viewer/sign-renderer/index.ts
+++ b/renderer/viewer/sign-renderer/index.ts
@@ -135,10 +135,10 @@ export const renderComponent = (
   const textWidths: number[] = []
 
   const renderText = (component: Message, parentFormatting?: Formatting | undefined) => {
-    if (component.text != null && typeof component.text !== 'string') {
+    if (component.text !== null && component.text !== undefined && typeof component.text !== 'string') {
       console.warn('renderText received non-string text value:', typeof component.text, component.text)
     }
-    const text = component.text != null ? String(component.text) : undefined
+    const text = component.text === null || component.text === undefined ? undefined : String(component.text)
     const formatting = {
       color: component.color ?? parentFormatting?.color,
       underlined: component.underlined ?? parentFormatting?.underlined,

--- a/src/inventoryWindows.ts
+++ b/src/inventoryWindows.ts
@@ -482,7 +482,12 @@ const openWindow = (type: string | undefined, title: string | any = undefined) =
       oldOnInventoryEvent(type, containing, windowIndex, inventoryIndex, item)
     }
   }
+  let jeiClickInProgress = false
   lastWindow.pwindow.onJeiClick = (slotItem, _index, isRightclick) => {
+    if (!slotItem) {
+      console.warn('onJeiClick called with undefined slotItem')
+      return
+    }
     if (versionToNumber(bot.version) < versionToNumber('1.13')) {
       alert('Item give is broken on 1.12.2 and below, we are working on it!')
       return
@@ -504,8 +509,15 @@ const openWindow = (type: string | undefined, title: string | any = undefined) =
     })
     if (bot.game.gameMode === 'creative') {
       const freeSlot = bot.inventory.firstEmptyInventorySlot()
-      if (freeSlot === null) return
-      void bot.creative.setInventorySlot(freeSlot, item)
+      if (freeSlot === null) {
+        console.warn('[JEI] no free inventory slot available')
+        return
+      }
+      bot._client.write('set_creative_slot', {
+        slot: freeSlot,
+        item: PrismarineItem.toNotch(item)
+      })
+      bot._setSlot(freeSlot, item)
     } else {
       modelViewerState.model = undefined
       inv.canvasManager.children[0].showRecipesOrUsages(!isRightclick, mapSlots([item], true)[0])

--- a/src/inventoryWindows.ts
+++ b/src/inventoryWindows.ts
@@ -482,7 +482,6 @@ const openWindow = (type: string | undefined, title: string | any = undefined) =
       oldOnInventoryEvent(type, containing, windowIndex, inventoryIndex, item)
     }
   }
-  let jeiClickInProgress = false
   lastWindow.pwindow.onJeiClick = (slotItem, _index, isRightclick) => {
     if (!slotItem) {
       console.warn('onJeiClick called with undefined slotItem')
@@ -517,6 +516,7 @@ const openWindow = (type: string | undefined, title: string | any = undefined) =
         slot: freeSlot,
         item: PrismarineItem.toNotch(item)
       })
+      //@ts-expect-error
       bot._setSlot(freeSlot, item)
     } else {
       modelViewerState.model = undefined


### PR DESCRIPTION
On my 1.19.4 server, in creative mode, I'm not able to put items into my inventory from the blockpicker ("e").  It times out after 5 seconds.

Specifically, it seems like mineflayer is waiting for the server to ACK the set slot command.

Based on my research, the server will not do so.

So the client needs to optimistically apply the update locally. Asynchronously, if the server disagrees, it will send a set container slot command to the client to force the client into the state it does agree with. I don't know how to fix this in the mineflayer codebase, but in my client doing the set_slot manually seems to fix the issue:

I'm not a MC protocol expert, but I can confirm the patch fixes the issue for me.  I don't know if this is correct for other versions.

I believe the correct fix actually belongs in the Mineflayer repository, but I'm not qualified to work on it.

I believe [Mineflayer Issue 2865](https://github.com/PrismarineJS/mineflayer/issues/2865), reported in 2022, is the same problem.  I've commented on it with my notes about my workaround, so maybe someone more knowledgable can fix it properly.  Until then, feel free to take this, or use it for inspiration for a proper fix!

Oh, also, there is another small change I forgot to mention, to fix a console error about renderText receiving a non string text value..  This probably only addresses the symptom, but I don't understand enough about the codebase to know how to fix the root cause...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent crashes from unexpected non-string text in rendering; now logs a warning and coerces values safely.
  * Improved creative-mode inventory handling to reliably place items into free slots and update local state, with warnings when no slot is available.
  * Replaced silent failures with diagnostic warnings for unexpected conditions to improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->