### PR TITLE
fix reset onFire state on respawn

### DIFF
--- a/src/entities.ts
+++ b/src/entities.ts
@@ -339,7 +339,9 @@ const ENTITY_FLAGS = {
 let onFireTimeout: NodeJS.Timeout | undefined
 const updateEntityStates = (entityId: number, onFire: boolean, timeout?: boolean) => {
   if (entityId !== bot.entity.id) return
-  appViewer.playerState.reactive.onFire = onFire
+  if (appViewer.playerState.reactive.onFire !== onFire) {
+    appViewer.playerState.reactive.onFire = onFire
+  }
   if (onFireTimeout) {
     clearTimeout(onFireTimeout)
     onFireTimeout = undefined

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -342,9 +342,11 @@ const updateEntityStates = (entityId: number, onFire: boolean, timeout?: boolean
   appViewer.playerState.reactive.onFire = onFire
   if (onFireTimeout) {
     clearTimeout(onFireTimeout)
+    onFireTimeout = undefined
   }
   if (timeout) {
     onFireTimeout = setTimeout(() => {
+      onFireTimeout = undefined
       updateEntityStates(entityId, false, false)
     }, 5000)
   }
@@ -360,6 +362,9 @@ function handleEntityMetadata (packet: { entityId: number, metadata: Array<{ key
 
   // Update fire state if flags were found
   if (flagsData) {
-    appViewer.playerState.reactive.onFire = (flagsData.value & ENTITY_FLAGS.ON_FIRE) !== 0
+    const newOnFire = (flagsData.value & ENTITY_FLAGS.ON_FIRE) !== 0
+    if (appViewer.playerState.reactive.onFire !== newOnFire) {
+      appViewer.playerState.reactive.onFire = newOnFire
+    }
   }
 }

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -143,7 +143,6 @@ customEvents.on('gameLoaded', () => {
       clearTimeout(onFireTimeout)
       onFireTimeout = undefined
     }
-    appViewer.playerState.reactive.onFire = false
   })
 
   bot.on('respawn', () => {
@@ -339,9 +338,7 @@ const ENTITY_FLAGS = {
 let onFireTimeout: NodeJS.Timeout | undefined
 const updateEntityStates = (entityId: number, onFire: boolean, timeout?: boolean) => {
   if (entityId !== bot.entity.id) return
-  if (appViewer.playerState.reactive.onFire !== onFire) {
-    appViewer.playerState.reactive.onFire = onFire
-  }
+  appViewer.playerState.reactive.onFire = onFire
   if (onFireTimeout) {
     clearTimeout(onFireTimeout)
     onFireTimeout = undefined

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -338,7 +338,9 @@ const ENTITY_FLAGS = {
 let onFireTimeout: NodeJS.Timeout | undefined
 const updateEntityStates = (entityId: number, onFire: boolean, timeout?: boolean) => {
   if (entityId !== bot.entity.id) return
-  appViewer.playerState.reactive.onFire = onFire
+  if (appViewer.playerState.reactive.onFire !== onFire) {
+    appViewer.playerState.reactive.onFire = onFire
+  }
   if (onFireTimeout) {
     clearTimeout(onFireTimeout)
     onFireTimeout = undefined

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -141,13 +141,17 @@ customEvents.on('gameLoaded', () => {
   bot.on('end', () => {
     if (onFireTimeout) {
       clearTimeout(onFireTimeout)
+      onFireTimeout = undefined
     }
+    appViewer.playerState.reactive.onFire = false
   })
 
   bot.on('respawn', () => {
     if (onFireTimeout) {
       clearTimeout(onFireTimeout)
+      onFireTimeout = undefined
     }
+    appViewer.playerState.reactive.onFire = false
   })
 
   const updateCamera = (entity: Entity) => {
@@ -356,7 +360,6 @@ function handleEntityMetadata (packet: { entityId: number, metadata: Array<{ key
 
   // Update fire state if flags were found
   if (flagsData) {
-    const wasOnFire = appViewer.playerState.reactive.onFire
     appViewer.playerState.reactive.onFire = (flagsData.value & ENTITY_FLAGS.ON_FIRE) !== 0
   }
 }


### PR DESCRIPTION
## Summary
Fixes #500

The first-person fire overlay effect persists indefinitely because the `onFire` reactive state is never reset on `respawn` or `end` events.

## Root Cause

In `src/entities.ts`, the `respawn` and `end` event handlers clear the `onFireTimeout` timer but do **not** reset `appViewer.playerState.reactive.onFire = false`. This means:

1. Player catches fire -> `onFire` set to `true` via `entity_metadata` or `entity_status`
2. Player dies and respawns -> timeout cleared, but `onFire` stays `true`
3. `FireRenderer.tsx` keeps rendering the fire overlay forever

## Fix

- Reset `onFire = false` in both `respawn` and `end` handlers
- Set `onFireTimeout = undefined` after clearing to prevent stale references
- Remove unused `wasOnFire` variable in `handleEntityMetadata`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fire state now reliably resets during respawn and end events, preventing stuck "on fire" visuals.
  * Timed fire effects now clear cleanly to avoid lingering or duplicated on-fire displays.
  * On-fire status updates only occur when the state actually changes, reducing unnecessary visual updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->