### PR TITLE
FEAT add setting to always display typing indicator

### DIFF
--- a/src/defaultOptions.ts
+++ b/src/defaultOptions.ts
@@ -70,6 +70,7 @@ export const defaultOptions = {
   debugResponseTimeIndicator: false,
   chatPingExtension: true,
   chatSpellCheckEnabled: false,
+  chatTypingIndicator: false,
   // antiAliasing: false,
   topRightTimeDisplay: 'only-fullscreen' as 'only-fullscreen' | 'always' | 'never',
 

--- a/src/defaultOptions.ts
+++ b/src/defaultOptions.ts
@@ -70,7 +70,7 @@ export const defaultOptions = {
   debugResponseTimeIndicator: false,
   chatPingExtension: true,
   chatSpellCheckEnabled: false,
-  chatTypingIndicator: false,
+  chatAlwaysDisplayTypingIndicator: false,
   // antiAliasing: false,
   topRightTimeDisplay: 'only-fullscreen' as 'only-fullscreen' | 'always' | 'never',
 

--- a/src/optionsGuiScheme.tsx
+++ b/src/optionsGuiScheme.tsx
@@ -275,8 +275,8 @@ export const guiOptionsScheme: {
       },
       chatPingExtension: {
       },
-      chatTypingIndicator: {
-        text: 'Typing Indicator',
+      chatAlwaysDisplayTypingIndicator: {
+        text: 'Always Show Typing',
       },
     },
     {

--- a/src/optionsGuiScheme.tsx
+++ b/src/optionsGuiScheme.tsx
@@ -274,7 +274,10 @@ export const guiOptionsScheme: {
         text: 'Text Select',
       },
       chatPingExtension: {
-      }
+      },
+      chatTypingIndicator: {
+        text: 'Typing Indicator',
+      },
     },
     {
       custom () {

--- a/src/optionsGuiScheme.tsx
+++ b/src/optionsGuiScheme.tsx
@@ -276,7 +276,7 @@ export const guiOptionsScheme: {
       chatPingExtension: {
       },
       chatAlwaysDisplayTypingIndicator: {
-        text: 'Always Show Typing',
+        text: 'Always Show Typing Indicator',
       },
     },
     {

--- a/src/react/Chat.tsx
+++ b/src/react/Chat.tsx
@@ -1,7 +1,6 @@
 import { proxy, subscribe, useSnapshot } from 'valtio'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { isStringAllowed, MessageFormatPart } from '../chatUtils'
-import { gameAdditionalState } from '../globalState'
 import { MessagePart } from './MessageFormatted'
 import './Chat.css'
 import { isIos, reactKeyForMessage } from './utils'
@@ -9,6 +8,7 @@ import Button from './Button'
 import { pixelartIcons } from './PixelartIcon'
 import { useScrollBehavior } from './hooks/useScrollBehavior'
 import { withInjectableUi } from './extendableSystem'
+import { useTypingIndicatorText } from './useTypingIndicatorText'
 
 export type Message = {
   parts: MessageFormatPart[],
@@ -138,16 +138,7 @@ const ChatBase = ({
   const [rightNowAtBottom, setRightNowAtBottom] = useState(false)
 
   // Typing indicator state
-  const { typingUsers } = useSnapshot(gameAdditionalState)
-  const typingIndicatorText = useMemo(() => {
-    const activeTypingUsers = typingUsers.filter(user => !user.timestamp || Date.now() - user.timestamp < 2000)
-    if (activeTypingUsers.length === 0) return ''
-    if (activeTypingUsers.length === 1) return `${activeTypingUsers[0]?.username || 'Someone'} is typing...`
-    if (activeTypingUsers.length === 2) return `${activeTypingUsers[0]?.username || 'Someone'} and ${activeTypingUsers[1]?.username || 'Someone'} are typing...`
-    const usernames = activeTypingUsers.slice(0, -1).map(user => user?.username || 'Someone').join(', ')
-    const lastUser = activeTypingUsers.at(-1)?.username || 'Someone'
-    return `${usernames} and ${lastUser} are typing...`
-  }, [typingUsers])
+  const typingIndicatorText = useTypingIndicatorText()
 
   const typingIndicator = typingIndicatorText ? (
     <div style={{
@@ -178,16 +169,6 @@ const ChatBase = ({
       </div>
     </div>
   ) : null
-
-  // Clean up old typing users every second
-  useEffect(() => {
-    const interval = setInterval(() => {
-      const now = Date.now()
-      gameAdditionalState.typingUsers = gameAdditionalState.typingUsers.filter(user => !user.timestamp || now - user.timestamp < 2000)
-    }, 1000)
-
-    return () => clearInterval(interval)
-  }, [])
 
   useEffect(() => {
     if (!debugChatScroll) return

--- a/src/react/ChatProvider.tsx
+++ b/src/react/ChatProvider.tsx
@@ -53,7 +53,7 @@ const ChatProviderBase = () => {
     debugChatScroll,
     chatPingExtension,
     chatSpellCheckEnabled,
-    chatTypingIndicator
+    chatAlwaysDisplayTypingIndicator
   } = useSnapshot(options)
   const isUsingMicrosoftAuth = useMemo(() => !!lastConnectOptions.value?.authenticatedAccount, [])
   const { forwardChat } = useSnapshot(viewerVersionState)
@@ -191,7 +191,7 @@ const ChatProviderBase = () => {
         }
       }}
     />
-    {chatTypingIndicator && !isChatActive && <TypingIndicatorOverlay />}
+    {chatAlwaysDisplayTypingIndicator && !isChatActive && <TypingIndicatorOverlay />}
   </>
 }
 

--- a/src/react/ChatProvider.tsx
+++ b/src/react/ChatProvider.tsx
@@ -12,6 +12,28 @@ import { hideNotification, notificationProxy, showNotification } from './Notific
 import { getServerIndex, updateLoadedServerData } from './serversStorage'
 import { showOptionsModal } from './SelectOption'
 import { withInjectableUi } from './extendableSystem'
+import { useTypingIndicatorText } from './useTypingIndicatorText'
+
+const TypingIndicatorOverlay = () => {
+  const typingIndicatorText = useTypingIndicatorText()
+  if (!typingIndicatorText) return null
+
+  return (
+    <div style={{
+      position: 'fixed',
+      bottom: 3,
+      left: 2,
+      fontSize: '9px',
+      color: 'white',
+      textShadow: '1px 1px 0px #3f3f3f',
+      fontFamily: 'mojangles, minecraft, monospace',
+      padding: '2px 4px',
+      zIndex: 40,
+    }}>
+      {typingIndicatorText}
+    </div>
+  )
+}
 
 const ChatProviderBase = () => {
   const [messages, setMessages] = useState([] as Message[])
@@ -30,7 +52,8 @@ const ChatProviderBase = () => {
     chatVanillaRestrictions,
     debugChatScroll,
     chatPingExtension,
-    chatSpellCheckEnabled
+    chatSpellCheckEnabled,
+    chatTypingIndicator
   } = useSnapshot(options)
   const isUsingMicrosoftAuth = useMemo(() => !!lastConnectOptions.value?.authenticatedAccount, [])
   const { forwardChat } = useSnapshot(viewerVersionState)
@@ -67,106 +90,109 @@ const ChatProviderBase = () => {
 
   const disabledReason = disconnectedCleanup ? 'You have been disconnected from the server on ' + new Date(disconnectedCleanup.date).toLocaleString() : undefined
 
-  return <Chat
-    chatVanillaRestrictions={chatVanillaRestrictions}
-    debugChatScroll={debugChatScroll}
-    allowSelection={chatSelect}
-    usingTouch={!!usingTouch}
-    opacity={(isChatActive ? chatOpacityOpened : chatOpacity) / 100}
-    messages={messages}
-    opened={isChatActive}
-    placeholder={forwardChat || !viewerConnection ? undefined : 'Chat forwarding is not enabled in the plugin settings'}
-    inputDisabled={disabledReason}
-    currentPlayerName={chatPingExtension ? bot.username : undefined}
-    spellCheckEnabled={chatSpellCheckEnabled}
-    onSpellCheckEnabledChange={(enabled) => {
-      options.chatSpellCheckEnabled = enabled
-    }}
-    getPingComplete={async (value) => {
-      const players = Object.keys(bot.players)
-      return players.filter(name => (!value || name.toLowerCase().includes(value.toLowerCase())) && name !== bot.username).map(name => `@${name}`)
-    }}
-    sendMessage={async (message) => {
+  return <>
+    <Chat
+      chatVanillaRestrictions={chatVanillaRestrictions}
+      debugChatScroll={debugChatScroll}
+      allowSelection={chatSelect}
+      usingTouch={!!usingTouch}
+      opacity={(isChatActive ? chatOpacityOpened : chatOpacity) / 100}
+      messages={messages}
+      opened={isChatActive}
+      placeholder={forwardChat || !viewerConnection ? undefined : 'Chat forwarding is not enabled in the plugin settings'}
+      inputDisabled={disabledReason}
+      currentPlayerName={chatPingExtension ? bot.username : undefined}
+      spellCheckEnabled={chatSpellCheckEnabled}
+      onSpellCheckEnabledChange={(enabled) => {
+        options.chatSpellCheckEnabled = enabled
+      }}
+      getPingComplete={async (value) => {
+        const players = Object.keys(bot.players)
+        return players.filter(name => (!value || name.toLowerCase().includes(value.toLowerCase())) && name !== bot.username).map(name => `@${name}`)
+      }}
+      sendMessage={async (message) => {
       // Record ping command time
-      if (message === '/ping') {
-        lastPingTime.current = Date.now()
-      }
+        if (message === '/ping') {
+          lastPingTime.current = Date.now()
+        }
 
-      const builtinHandled = tryHandleBuiltinCommand(message)
-      if (getServerIndex() !== undefined && (message.startsWith('/login') || message.startsWith('/register')) && options.saveLoginPassword !== 'never') {
-        const savePassword = () => {
-          let hadPassword = false
-          updateLoadedServerData((server) => {
-            server.autoLogin ??= {}
-            const password = message.split(' ')[1]
-            hadPassword = !!server.autoLogin[bot.username]
-            server.autoLogin[bot.username] = password
-            return { ...server }
-          })
-          if (options.saveLoginPassword === 'always') {
-            const message = hadPassword ? 'Password updated in browser for auto-login' : 'Password saved in browser for auto-login'
-            showNotification(message, undefined, false, undefined)
+        const builtinHandled = tryHandleBuiltinCommand(message)
+        if (getServerIndex() !== undefined && (message.startsWith('/login') || message.startsWith('/register')) && options.saveLoginPassword !== 'never') {
+          const savePassword = () => {
+            let hadPassword = false
+            updateLoadedServerData((server) => {
+              server.autoLogin ??= {}
+              const password = message.split(' ')[1]
+              hadPassword = !!server.autoLogin[bot.username]
+              server.autoLogin[bot.username] = password
+              return { ...server }
+            })
+            if (options.saveLoginPassword === 'always') {
+              const message = hadPassword ? 'Password updated in browser for auto-login' : 'Password saved in browser for auto-login'
+              showNotification(message, undefined, false, undefined)
+            } else {
+              hideNotification()
+            }
+          }
+          if (options.saveLoginPassword === 'prompt') {
+            showNotification('Click here to save your password in browser for auto-login', undefined, false, undefined, savePassword)
           } else {
+            savePassword()
+          }
+          notificationProxy.id = 'auto-login'
+          const listener = () => {
             hideNotification()
           }
+          bot.on('kicked', listener)
+          setTimeout(() => {
+            bot.removeListener('kicked', listener)
+          }, 2000)
         }
-        if (options.saveLoginPassword === 'prompt') {
-          showNotification('Click here to save your password in browser for auto-login', undefined, false, undefined, savePassword)
-        } else {
-          savePassword()
-        }
-        notificationProxy.id = 'auto-login'
-        const listener = () => {
-          hideNotification()
-        }
-        bot.on('kicked', listener)
-        setTimeout(() => {
-          bot.removeListener('kicked', listener)
-        }, 2000)
-      }
-      if (!builtinHandled) {
-        if (chatVanillaRestrictions && !miscUiState.flyingSquid) {
-          const validation = isStringAllowed(message)
-          if (!validation.valid) {
-            const choice = await showOptionsModal(`Can't send invalid characters to vanilla server (${validation.invalid?.join(', ')}). You can use them only in command blocks.`, [
-              'Remove Them & Send'
-            ])
-            if (!choice) return
-            message = validation.clean!
+        if (!builtinHandled) {
+          if (chatVanillaRestrictions && !miscUiState.flyingSquid) {
+            const validation = isStringAllowed(message)
+            if (!validation.valid) {
+              const choice = await showOptionsModal(`Can't send invalid characters to vanilla server (${validation.invalid?.join(', ')}). You can use them only in command blocks.`, [
+                'Remove Them & Send'
+              ])
+              if (!choice) return
+              message = validation.clean!
+            }
           }
-        }
 
-        if (message) {
-          bot.chat(message)
+          if (message) {
+            bot.chat(message)
+          }
         }
-      }
-    }}
-    onClose={() => {
-      hideCurrentModal()
-    }}
-    fetchCompletionItems={async (triggerKind, completeValue) => {
-      if ((triggerKind === 'explicit' || options.autoRequestCompletions)) {
-        let items = [] as string[]
-        try {
-          items = await bot.tabComplete(completeValue, true, true)
-        } catch (err) { }
-        if (typeof items[0] === 'object') {
+      }}
+      onClose={() => {
+        hideCurrentModal()
+      }}
+      fetchCompletionItems={async (triggerKind, completeValue) => {
+        if ((triggerKind === 'explicit' || options.autoRequestCompletions)) {
+          let items = [] as string[]
+          try {
+            items = await bot.tabComplete(completeValue, true, true)
+          } catch (err) { }
+          if (typeof items[0] === 'object') {
           // @ts-expect-error
-          if (items[0].match) items = items.map(i => i.match)
-        }
-        if (completeValue === '/') {
-          if (!items[0]?.startsWith('/')) {
+            if (items[0].match) items = items.map(i => i.match)
+          }
+          if (completeValue === '/') {
+            if (!items[0]?.startsWith('/')) {
             // normalize
-            items = items.map(item => `/${item}`)
+              items = items.map(item => `/${item}`)
+            }
+            if (items.length) {
+              items = [...items, ...getBuiltinCommandsList()]
+            }
           }
-          if (items.length) {
-            items = [...items, ...getBuiltinCommandsList()]
-          }
+          return items
         }
-        return items
-      }
-    }}
-  />
+      }}
+    />
+    {chatTypingIndicator && !isChatActive && <TypingIndicatorOverlay />}
+  </>
 }
 
 export default withInjectableUi(ChatProviderBase, 'chatProvider')

--- a/src/react/useTypingIndicatorText.ts
+++ b/src/react/useTypingIndicatorText.ts
@@ -1,0 +1,28 @@
+import { useEffect, useMemo } from 'react'
+import { useSnapshot } from 'valtio'
+import { gameAdditionalState } from '../globalState'
+
+export const useTypingIndicatorText = () => {
+  const { typingUsers } = useSnapshot(gameAdditionalState)
+
+  const typingIndicatorText = useMemo(() => {
+    const activeTypingUsers = typingUsers.filter(user => !user.timestamp || Date.now() - user.timestamp < 2000)
+    if (activeTypingUsers.length === 0) return ''
+    if (activeTypingUsers.length === 1) return `${activeTypingUsers[0]?.username || 'Someone'} is typing...`
+    if (activeTypingUsers.length === 2) return `${activeTypingUsers[0]?.username || 'Someone'} and ${activeTypingUsers[1]?.username || 'Someone'} are typing...`
+    const usernames = activeTypingUsers.slice(0, -1).map(user => user?.username || 'Someone').join(', ')
+    const lastUser = activeTypingUsers.at(-1)?.username || 'Someone'
+    return `${usernames} and ${lastUser} are typing...`
+  }, [typingUsers])
+
+  // Cleanup stale typing users every second
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const now = Date.now()
+      gameAdditionalState.typingUsers = gameAdditionalState.typingUsers.filter(user => !user.timestamp || now - user.timestamp < 2000)
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  return typingIndicatorText
+}

--- a/src/react/useTypingIndicatorText.ts
+++ b/src/react/useTypingIndicatorText.ts
@@ -19,7 +19,10 @@ export const useTypingIndicatorText = () => {
   useEffect(() => {
     const interval = setInterval(() => {
       const now = Date.now()
-      gameAdditionalState.typingUsers = gameAdditionalState.typingUsers.filter(user => !user.timestamp || now - user.timestamp < 2000)
+      const hasExpired = gameAdditionalState.typingUsers.some(user => user.timestamp && now - user.timestamp >= 2000)
+      if (hasExpired) {
+        gameAdditionalState.typingUsers = gameAdditionalState.typingUsers.filter(user => !user.timestamp || now - user.timestamp < 2000)
+      }
     }, 1000)
     return () => clearInterval(interval)
   }, [])


### PR DESCRIPTION
Closes #501

### Changes
- Added `chatTypingIndicator` option in Interface → Chat settings
- Typing indicator is now shown even when chat is closed (when enabled)
- Extracted typing indicator logic into `useTypingIndicatorText` hook to avoid duplication

### Screenshots
<img width="495" height="76" alt="image" src="https://github.com/user-attachments/assets/35234d85-1775-49d5-9ca8-71d4686b4db7" />
<img width="1368" height="234" alt="image" src="https://github.com/user-attachments/assets/fcd957c2-8487-4ad5-87e3-2b6ef761185b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to always show the typing indicator; when enabled an overlay displays who is typing even if chat isn't active.

* **Refactor**
  * Reworked typing-indicator logic for more accurate, stable display and automatic pruning of stale typing entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->