### PR TITLE
feat: add debug modules panel with persistence

### DIFF
--- a/src/controls.ts
+++ b/src/controls.ts
@@ -750,6 +750,13 @@ export const f3Keybinds: Array<{
     },
     mobileTitle: 'Copy Server Resource Pack',
     enabled: () => !!gameAdditionalState.usingServerResourcePack
+  },
+  {
+    key: 'KeyM',
+    action () {
+      ;(window as any).world?.toggleDebugModulesPanel()
+    },
+    mobileTitle: 'Debug Modules Panel',
   }
 ]
 

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -754,9 +754,9 @@ export const f3Keybinds: Array<{
   {
     key: 'KeyM',
     action () {
-      ;(window as any).world?.toggleDebugModulesPanel()
+      appViewer.backend?.backendMethods?.toggleDebugModulesPanel()
     },
-    mobileTitle: 'Debug Modules Panel',
+    mobileTitle: 'Renderer Debug Panel',
   }
 ]
 


### PR DESCRIPTION
#### Description

Adds a trigger for the renderer's debug modules panel to the F3 menu. The panel itself lives entirely in the renderer — client only calls `world.toggleDebugModulesPanel()`.

#### Changes

* Added "Debug Modules Panel" entry to `f3Keybinds` array with `F3+M` hotkey.
* Desktop: press `F3+M` to toggle the panel.
* Mobile: long-press F3 → select "Debug Modules Panel" from the menu.

#### Files Changed

* `src/controls.ts` — added f3Keybinds entry (+6 lines).

#### Dependencies

Requires the renderer PR to be merged first (provides `toggleDebugModulesPanel()` API).