### PR TITLE
feat: add walkDist/bob player state tracking for camera bobbing

### DIFF
--- a/src/mineflayer/playerState.ts
+++ b/src/mineflayer/playerState.ts
@@ -87,6 +87,7 @@ export class PlayerStateControllerMain {
     bot.on('physicsTick', () => {
       if (this.isUsingItem) this.reactive.itemUsageTicks++
       updateSneakingOrFlying()
+      this.updateWalkDistAndBob()
     })
     // todo move from gameAdditionalState to reactive directly
     subscribeKey(gameAdditionalState, 'isSneaking', () => {
@@ -144,6 +145,27 @@ export class PlayerStateControllerMain {
     } else {
       this.reactive.movementState = 'NOT_MOVING'
     }
+  }
+
+  private updateWalkDistAndBob () {
+    if (!bot?.entity || this.disableStateUpdates) return
+
+    const { velocity } = bot.entity
+    const horizontalDist = Math.sqrt(velocity.x * velocity.x + velocity.z * velocity.z)
+
+    // Save previous values for interpolation
+    this.reactive.prevWalkDist = this.reactive.walkDist
+    this.reactive.prevBob = this.reactive.bob
+
+    // Accumulate walk distance with dampening factor
+    this.reactive.walkDist += horizontalDist * 0.6
+
+    // Smooth bob amplitude — vanilla: onGround && !isDeadOrDying && !isSwimming
+    // isSwimming = sprinting + in water (not just touching water)
+    const isSwimming = bot.controlState.sprint && bot.entity.isInWater
+    const isDeadOrDying = (bot.entity.health ?? 20) <= 0
+    const bobTarget = (bot.entity.onGround && !isDeadOrDying && !isSwimming) ? Math.min(0.1, horizontalDist) : 0
+    this.reactive.bob += (bobTarget - this.reactive.bob) * 0.4
   }
 
   // #region Held Item State

--- a/src/mineflayer/playerState.ts
+++ b/src/mineflayer/playerState.ts
@@ -162,7 +162,7 @@ export class PlayerStateControllerMain {
 
     // Smooth bob amplitude — vanilla: onGround && !isDeadOrDying && !isSwimming
     // isSwimming = sprinting + in water (not just touching water)
-    const isSwimming = bot.controlState.sprint && bot.entity.isInWater
+    const isSwimming = bot.controlState.sprint && this.reactive.inWater
     const isDeadOrDying = (bot.entity.health ?? 20) <= 0
     const bobTarget = (bot.entity.onGround && !isDeadOrDying && !isSwimming) ? Math.min(0.1, horizontalDist) : 0
     this.reactive.bob += (bobTarget - this.reactive.bob) * 0.4


### PR DESCRIPTION
## Description

Adds walk distance and bob amplitude tracking to the player state for camera bobbing support in the renderer.

> **Companion PR:** Requires [minecraft-renderer — feat/camera-bobbing](https://github.com/zardoy/minecraft-renderer/pull/12) which implements camera bobbing rendering.

## Changes

- **Added `updateWalkDistAndBob()` method** to `PlayerState` class — computes `walkDist` and `bob` on each physics tick (20 TPS) using mineflayer's `bot.entity.velocity`. Implements vanilla's accumulation and smoothing formulas:
  - `walkDist += horizontalDist * 0.6` (vanilla Entity.move accumulation factor)
  - `bob += (target - bob) * 0.4` where target = `min(0.1, horizontalDist)` (vanilla AbstractClientPlayer.updateBob cap)
  - Zero-bob conditions match vanilla: `onGround && !isDeadOrDying && !isSwimming`
  - Previous values saved for interpolation before each update

## Files Changed

| File | Change |
|------|--------|
| `src/mineflayer/playerState.ts` | Added `updateWalkDistAndBob()` method, called from `physicsTick` handler |

## Testing

- TypeScript typecheck passes.
