### PR TITLE
fix: patch mineflayer dimension type lookup for proxy/modded servers

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,7 +222,8 @@
     "patchedDependencies": {
       "pixelarticons@1.8.1": "patches/pixelarticons@1.8.1.patch",
       "mineflayer-item-map-downloader@1.2.0": "patches/mineflayer-item-map-downloader@1.2.0.patch",
-      "minecraft-protocol": "patches/minecraft-protocol@1.66.0.patch"
+      "minecraft-protocol": "patches/minecraft-protocol@1.66.0.patch",
+      "mineflayer": "patches/mineflayer.patch"
     },
     "ignoredBuiltDependencies": [
       "canvas",

--- a/patches/mineflayer.patch
+++ b/patches/mineflayer.patch
@@ -1,0 +1,35 @@
+diff --git a/lib/plugins/game.js b/lib/plugins/game.js
+--- a/lib/plugins/game.js
++++ b/lib/plugins/game.js
+@@ -47,7 +47,18 @@
+     } else if (bot.supportFeature('dimensionIsAString')) {
+       bot.game.dimension = packet.dimension.replace('minecraft:', '')
+     } else if (bot.supportFeature('dimensionIsAWorld')) {
+-      bot.game.dimension = packet.worldName.replace('minecraft:', '')
++      if (bot.supportFeature('dimensionDataInCodec')) {
++        // For 1.19+, we need the dimension TYPE name (not the world/level name) so
++        // the codec lookup succeeds. In login packets the type is "worldType"; in
++        // respawn packets it is "dimension". worldName is the level name which may
++        // differ from the type on proxy/modded servers.
++        const dimType = packet.worldType ?? packet.dimension
++        bot.game.dimension = typeof dimType === 'string'
++          ? dimType.replace('minecraft:', '')
++          : packet.worldName.replace('minecraft:', '')
++      } else {
++        bot.game.dimension = packet.worldName.replace('minecraft:', '')
++      }
+     } else {
+       throw new Error('Unsupported dimension type in login packet')
+     }
+@@ -60,11 +71,6 @@
+     bot.game.height = 256
+
+     if (bot.supportFeature('dimensionDataInCodec')) { // 1.19+
+-      // pre 1.20.5 before we consolidated login and respawn's SpawnInfo structure into one type,
+-      // "dimension" was called "worldType" in login_packet's payload but not respawn.
+-      if (packet.worldType && !bot.game.dimension) {
+-        bot.game.dimension = packet.worldType.replace('minecraft:', '')
+-      }
+       const dimData = bot.registry.dimensionsByName[bot.game.dimension]
+       if (dimData) {
+         bot.game.minY = dimData.minY

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ patchedDependencies:
   minecraft-protocol:
     hash: a0fc92234601e93b1e536d8d7cc9bf80a9df670d821e1d12746f261d15954fae
     path: patches/minecraft-protocol@1.66.0.patch
+  mineflayer:
+    hash: d45b8b88919cda61aa7a6e69e47b5f09c09f4b3fcf0885703c7745db5f0877b9
+    path: patches/mineflayer.patch
   mineflayer-item-map-downloader@1.2.0:
     hash: a731ebbace2d8790c973ab3a5ba33494a6e9658533a9710dd8ba36f86db061ad
     path: patches/mineflayer-item-map-downloader@1.2.0.patch
@@ -122,7 +125,7 @@ importers:
         version: 10.1.6
       flying-squid:
         specifier: npm:@zardoy/flying-squid@^0.0.119
-        version: '@zardoy/flying-squid@0.0.119(encoding@0.1.13)(prismarine-registry@1.11.0)'
+        version: '@zardoy/flying-squid@0.0.119(encoding@0.1.13)'
       framer-motion:
         specifier: ^12.9.2
         version: 12.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -140,7 +143,7 @@ importers:
         version: 4.17.21
       mcraft-fun-mineflayer:
         specifier: ^0.1.23
-        version: 0.1.23(encoding@0.1.13)(mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/f94428c114162ee5d0bfcf0c23654a356be7c2f1(encoding@0.1.13))
+        version: 0.1.23(encoding@0.1.13)(mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/f94428c114162ee5d0bfcf0c23654a356be7c2f1(patch_hash=d45b8b88919cda61aa7a6e69e47b5f09c09f4b3fcf0885703c7745db5f0877b9)(encoding@0.1.13))
       minecraft-data:
         specifier: 3.106.0
         version: 3.106.0
@@ -345,7 +348,7 @@ importers:
         version: https://codeload.github.com/zardoy/minecraft-inventory-gui/tar.gz/ae382e30ad66c3ca40f51ff3376605e8c67413db(@types/react@18.3.18)(react@18.3.1)
       mineflayer:
         specifier: github:zardoy/mineflayer#gen-the-master
-        version: https://codeload.github.com/zardoy/mineflayer/tar.gz/f94428c114162ee5d0bfcf0c23654a356be7c2f1(encoding@0.1.13)
+        version: https://codeload.github.com/zardoy/mineflayer/tar.gz/f94428c114162ee5d0bfcf0c23654a356be7c2f1(patch_hash=d45b8b88919cda61aa7a6e69e47b5f09c09f4b3fcf0885703c7745db5f0877b9)(encoding@0.1.13)
       mineflayer-mouse:
         specifier: ^0.1.26
         version: 0.1.26
@@ -433,13 +436,13 @@ importers:
         version: 1.3.9
       prismarine-block:
         specifier: github:zardoy/prismarine-block#next-era
-        version: https://codeload.github.com/zardoy/prismarine-block/tar.gz/853c559bff2b402863ee9a75b125a3ca320838f9(prismarine-registry@1.11.0)
+        version: https://codeload.github.com/zardoy/prismarine-block/tar.gz/853c559bff2b402863ee9a75b125a3ca320838f9
       prismarine-chunk:
         specifier: github:zardoy/prismarine-chunk#master
         version: https://codeload.github.com/zardoy/prismarine-chunk/tar.gz/ec44d01fbe2e3a310c605761688a85119f056332(minecraft-data@3.106.0)
       prismarine-schematic:
         specifier: ^1.2.0
-        version: 1.2.3(prismarine-registry@1.11.0)
+        version: 1.2.3
       process:
         specifier: ^0.11.10
         version: 0.11.10
@@ -11390,8 +11393,8 @@ snapshots:
     dependencies:
       '@nxg-org/mineflayer-util-plugin': 1.8.4
       minecraft-data: 3.106.0
-      mineflayer: https://codeload.github.com/zardoy/mineflayer/tar.gz/f94428c114162ee5d0bfcf0c23654a356be7c2f1(encoding@0.1.13)
-      prismarine-block: https://codeload.github.com/zardoy/prismarine-block/tar.gz/853c559bff2b402863ee9a75b125a3ca320838f9(prismarine-registry@1.11.0)
+      mineflayer: https://codeload.github.com/zardoy/mineflayer/tar.gz/f94428c114162ee5d0bfcf0c23654a356be7c2f1(patch_hash=d45b8b88919cda61aa7a6e69e47b5f09c09f4b3fcf0885703c7745db5f0877b9)(encoding@0.1.13)
+      prismarine-block: https://codeload.github.com/zardoy/prismarine-block/tar.gz/853c559bff2b402863ee9a75b125a3ca320838f9
       prismarine-item: 1.18.0
       prismarine-physics: https://codeload.github.com/zardoy/prismarine-physics/tar.gz/353e25b800149393f40539ec381218be44cbb03b
       vec3: 0.1.10
@@ -13140,7 +13143,7 @@ snapshots:
       '@types/emscripten': 1.40.0
       tslib: 1.14.1
 
-  '@zardoy/flying-squid@0.0.119(encoding@0.1.13)(prismarine-registry@1.11.0)':
+  '@zardoy/flying-squid@0.0.119(encoding@0.1.13)':
     dependencies:
       '@tootallnate/once': 2.0.0
       chalk: 5.4.1
@@ -13155,7 +13158,7 @@ snapshots:
       mkdirp: 2.1.6
       node-gzip: 1.1.2
       node-rsa: 1.1.1
-      prismarine-block: https://codeload.github.com/zardoy/prismarine-block/tar.gz/853c559bff2b402863ee9a75b125a3ca320838f9(prismarine-registry@1.11.0)
+      prismarine-block: https://codeload.github.com/zardoy/prismarine-block/tar.gz/853c559bff2b402863ee9a75b125a3ca320838f9
       prismarine-chunk: https://codeload.github.com/zardoy/prismarine-chunk/tar.gz/ec44d01fbe2e3a310c605761688a85119f056332(minecraft-data@3.106.0)
       prismarine-entity: 2.5.0
       prismarine-item: 1.18.0
@@ -13175,7 +13178,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - encoding
-      - prismarine-registry
       - supports-color
 
   '@zardoy/flying-squid@0.0.49(encoding@0.1.13)':
@@ -17053,12 +17055,12 @@ snapshots:
     dependencies:
       minecraft-data: 3.106.0
 
-  mcraft-fun-mineflayer@0.1.23(encoding@0.1.13)(mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/f94428c114162ee5d0bfcf0c23654a356be7c2f1(encoding@0.1.13)):
+  mcraft-fun-mineflayer@0.1.23(encoding@0.1.13)(mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/f94428c114162ee5d0bfcf0c23654a356be7c2f1(patch_hash=d45b8b88919cda61aa7a6e69e47b5f09c09f4b3fcf0885703c7745db5f0877b9)(encoding@0.1.13)):
     dependencies:
       '@zardoy/flying-squid': 0.0.49(encoding@0.1.13)
       exit-hook: 2.2.1
       minecraft-protocol: https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/3fabf16c61995b7a2c6d4d2902f7af99d0fe0a77(patch_hash=a0fc92234601e93b1e536d8d7cc9bf80a9df670d821e1d12746f261d15954fae)(encoding@0.1.13)
-      mineflayer: https://codeload.github.com/zardoy/mineflayer/tar.gz/f94428c114162ee5d0bfcf0c23654a356be7c2f1(encoding@0.1.13)
+      mineflayer: https://codeload.github.com/zardoy/mineflayer/tar.gz/f94428c114162ee5d0bfcf0c23654a356be7c2f1(patch_hash=d45b8b88919cda61aa7a6e69e47b5f09c09f4b3fcf0885703c7745db5f0877b9)(encoding@0.1.13)
       prismarine-item: 1.18.0
       ws: 8.18.1
     transitivePeerDependencies:
@@ -17428,7 +17430,7 @@ snapshots:
 
   mineflayer-item-map-downloader@https://codeload.github.com/zardoy/mineflayer-item-map-downloader/tar.gz/a8d210ecdcf78dd082fa149a96e1612cc9747824(patch_hash=a731ebbace2d8790c973ab3a5ba33494a6e9658533a9710dd8ba36f86db061ad)(encoding@0.1.13):
     dependencies:
-      mineflayer: https://codeload.github.com/zardoy/mineflayer/tar.gz/f94428c114162ee5d0bfcf0c23654a356be7c2f1(encoding@0.1.13)
+      mineflayer: https://codeload.github.com/zardoy/mineflayer/tar.gz/f94428c114162ee5d0bfcf0c23654a356be7c2f1(patch_hash=d45b8b88919cda61aa7a6e69e47b5f09c09f4b3fcf0885703c7745db5f0877b9)(encoding@0.1.13)
       sharp: 0.30.7
     transitivePeerDependencies:
       - encoding
@@ -17443,13 +17445,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/f94428c114162ee5d0bfcf0c23654a356be7c2f1(encoding@0.1.13):
+  mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/f94428c114162ee5d0bfcf0c23654a356be7c2f1(patch_hash=d45b8b88919cda61aa7a6e69e47b5f09c09f4b3fcf0885703c7745db5f0877b9)(encoding@0.1.13):
     dependencies:
       '@nxg-org/mineflayer-physics-util': 1.8.19
       minecraft-data: 3.106.0
       minecraft-protocol: https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/3fabf16c61995b7a2c6d4d2902f7af99d0fe0a77(patch_hash=a0fc92234601e93b1e536d8d7cc9bf80a9df670d821e1d12746f261d15954fae)(encoding@0.1.13)
       prismarine-biome: 1.3.0(minecraft-data@3.106.0)(prismarine-registry@1.11.0)
-      prismarine-block: https://codeload.github.com/zardoy/prismarine-block/tar.gz/853c559bff2b402863ee9a75b125a3ca320838f9(prismarine-registry@1.11.0)
+      prismarine-block: https://codeload.github.com/zardoy/prismarine-block/tar.gz/853c559bff2b402863ee9a75b125a3ca320838f9
       prismarine-chat: 1.11.0
       prismarine-chunk: https://codeload.github.com/zardoy/prismarine-chunk/tar.gz/ec44d01fbe2e3a310c605761688a85119f056332(minecraft-data@3.106.0)
       prismarine-entity: 2.5.0
@@ -18243,7 +18245,7 @@ snapshots:
       minecraft-data: 3.106.0
       prismarine-registry: 1.11.0
 
-  prismarine-block@https://codeload.github.com/zardoy/prismarine-block/tar.gz/853c559bff2b402863ee9a75b125a3ca320838f9(prismarine-registry@1.11.0):
+  prismarine-block@https://codeload.github.com/zardoy/prismarine-block/tar.gz/853c559bff2b402863ee9a75b125a3ca320838f9:
     dependencies:
       minecraft-data: 3.106.0
       prismarine-biome: 1.3.0(minecraft-data@3.106.0)(prismarine-registry@1.11.0)
@@ -18251,8 +18253,6 @@ snapshots:
       prismarine-item: 1.18.0
       prismarine-nbt: 2.7.0
       prismarine-registry: 1.11.0
-    transitivePeerDependencies:
-      - prismarine-registry
 
   prismarine-chat@1.11.0:
     dependencies:
@@ -18263,7 +18263,7 @@ snapshots:
   prismarine-chunk@https://codeload.github.com/zardoy/prismarine-chunk/tar.gz/ec44d01fbe2e3a310c605761688a85119f056332(minecraft-data@3.106.0):
     dependencies:
       prismarine-biome: 1.3.0(minecraft-data@3.106.0)(prismarine-registry@1.11.0)
-      prismarine-block: https://codeload.github.com/zardoy/prismarine-block/tar.gz/853c559bff2b402863ee9a75b125a3ca320838f9(prismarine-registry@1.11.0)
+      prismarine-block: https://codeload.github.com/zardoy/prismarine-block/tar.gz/853c559bff2b402863ee9a75b125a3ca320838f9
       prismarine-nbt: 2.7.0
       prismarine-registry: 1.11.0
       smart-buffer: 4.2.0
@@ -18297,7 +18297,7 @@ snapshots:
 
   prismarine-provider-anvil@https://codeload.github.com/zardoy/prismarine-provider-anvil/tar.gz/1d548fac63fe977c8281f0a9a522b37e4d92d0b7(minecraft-data@3.106.0):
     dependencies:
-      prismarine-block: https://codeload.github.com/zardoy/prismarine-block/tar.gz/853c559bff2b402863ee9a75b125a3ca320838f9(prismarine-registry@1.11.0)
+      prismarine-block: https://codeload.github.com/zardoy/prismarine-block/tar.gz/853c559bff2b402863ee9a75b125a3ca320838f9
       prismarine-chunk: https://codeload.github.com/zardoy/prismarine-chunk/tar.gz/ec44d01fbe2e3a310c605761688a85119f056332(minecraft-data@3.106.0)
       prismarine-nbt: 2.7.0
       prismarine-world: https://codeload.github.com/zardoy/prismarine-world/tar.gz/ab2146c9933eef3247c3f64446de4ccc2c484c7c
@@ -18321,18 +18321,16 @@ snapshots:
   prismarine-registry@1.11.0:
     dependencies:
       minecraft-data: 3.106.0
-      prismarine-block: https://codeload.github.com/zardoy/prismarine-block/tar.gz/853c559bff2b402863ee9a75b125a3ca320838f9(prismarine-registry@1.11.0)
+      prismarine-block: https://codeload.github.com/zardoy/prismarine-block/tar.gz/853c559bff2b402863ee9a75b125a3ca320838f9
       prismarine-nbt: 2.7.0
 
-  prismarine-schematic@1.2.3(prismarine-registry@1.11.0):
+  prismarine-schematic@1.2.3:
     dependencies:
       minecraft-data: 3.106.0
-      prismarine-block: https://codeload.github.com/zardoy/prismarine-block/tar.gz/853c559bff2b402863ee9a75b125a3ca320838f9(prismarine-registry@1.11.0)
+      prismarine-block: https://codeload.github.com/zardoy/prismarine-block/tar.gz/853c559bff2b402863ee9a75b125a3ca320838f9
       prismarine-nbt: 2.7.0
       prismarine-world: https://codeload.github.com/zardoy/prismarine-world/tar.gz/ab2146c9933eef3247c3f64446de4ccc2c484c7c
       vec3: 0.1.10
-    transitivePeerDependencies:
-      - prismarine-registry
 
   prismarine-windows@2.9.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Backport upstream PrismarineJS/mineflayer fix for dimension type vs world name confusion in the game plugin
- On proxy/modded servers (e.g. BungeeCord/Velocity with Skyblock), bot.game.dimension was set from packet.worldName (e.g. bskyblock_world) but the dimension registry uses dimension type names (e.g. overworld). The registry lookup failed, causing minY/height to default to 0/256 instead of -64/384, which shifted all chunk geometry up by 64 blocks — making terrain invisible.

## Root cause

In Minecraft 1.19+, login/respawn packets have two separate fields:
- **Dimension type** (worldType in login, dimension in respawn) — e.g. overworld
- **World name** (worldName) — e.g. bskyblock_world

On vanilla servers these are the same value, but on proxy/modded servers they differ. The fork's mineflayer used the world name for the registry lookup, which failed for custom world names, causing chunk data to be parsed with wrong world height parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated dependency patch management configuration.

* **Bug Fixes**
  * Improved dimension handling for Minecraft 1.19+ versions with enhanced world type identification and fallback logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->