### PR TITLE
Feat: world performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "minecraft-data": "0.0.0",
     "minecraft-inventory": "^0.1.43",
     "minecraft-protocol": "github:PrismarineJS/node-minecraft-protocol#master",
-    "minecraft-renderer": "^0.1.37",
+    "minecraft-renderer": "^0.1.40",
     "mineflayer-item-map-downloader": "github:zardoy/mineflayer-item-map-downloader",
     "mojangson": "^2.0.4",
     "net-browserify": "github:zardoy/prismarinejs-net-browserify",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,7 +141,7 @@ importers:
         version: 4.17.21
       mcraft-fun-mineflayer:
         specifier: ^0.1.23
-        version: 0.1.23(encoding@0.1.13)(mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/afebaa007ac86a02eba8e38bb2bdfb85487d9b8b(encoding@0.1.13))
+        version: 0.1.23(encoding@0.1.13)(mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/6fe34e32c19657020cc48d95039e4b89361200b2(encoding@0.1.13))
       minecraft-data:
         specifier: 3.105.0
         version: 3.105.0
@@ -150,10 +150,10 @@ importers:
         version: 0.1.43(@xmcl/text-component@2.1.3)(mc-assets@0.2.72)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       minecraft-protocol:
         specifier: github:PrismarineJS/node-minecraft-protocol#master
-        version: https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/3fabf16c61995b7a2c6d4d2902f7af99d0fe0a77(patch_hash=a0fc92234601e93b1e536d8d7cc9bf80a9df670d821e1d12746f261d15954fae)(encoding@0.1.13)
+        version: https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/1cb735a2b38edbd97e5f778a72275008a59276f1(patch_hash=a0fc92234601e93b1e536d8d7cc9bf80a9df670d821e1d12746f261d15954fae)(encoding@0.1.13)
       minecraft-renderer:
-        specifier: ^0.1.37
-        version: 0.1.37(@types/react@18.3.18)(contro-max@0.1.12(typescript@5.5.4))(mc-assets@0.2.72)(minecraft-data@3.105.0)(react@18.3.1)(three@0.154.0)
+        specifier: ^0.1.40
+        version: 0.1.40(@types/react@18.3.18)(contro-max@0.1.12(typescript@5.5.4))(mc-assets@0.2.72)(minecraft-data@3.105.0)(react@18.3.1)(three@0.154.0)
       mineflayer-item-map-downloader:
         specifier: github:zardoy/mineflayer-item-map-downloader
         version: https://codeload.github.com/zardoy/mineflayer-item-map-downloader/tar.gz/a8d210ecdcf78dd082fa149a96e1612cc9747824(patch_hash=a731ebbace2d8790c973ab3a5ba33494a6e9658533a9710dd8ba36f86db061ad)(encoding@0.1.13)
@@ -349,7 +349,7 @@ importers:
         version: 0.2.72
       mineflayer:
         specifier: github:zardoy/mineflayer#gen-the-master
-        version: https://codeload.github.com/zardoy/mineflayer/tar.gz/afebaa007ac86a02eba8e38bb2bdfb85487d9b8b(encoding@0.1.13)
+        version: https://codeload.github.com/zardoy/mineflayer/tar.gz/6fe34e32c19657020cc48d95039e4b89361200b2(encoding@0.1.13)
       mineflayer-mouse:
         specifier: 0.1.28
         version: 0.1.28
@@ -3253,11 +3253,9 @@ packages:
   '@vitest/utils@0.34.6':
     resolution: {integrity: sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==}
 
-  '@xboxreplay/errors@0.1.0':
-    resolution: {integrity: sha512-Tgz1d/OIPDWPeyOvuL5+aai5VCcqObhPnlI3skQuf80GVF3k1I0lPCnGC+8Cm5PV9aLBT5m8qPcJoIUQ2U4y9g==}
-
-  '@xboxreplay/xboxlive-auth@3.3.3':
-    resolution: {integrity: sha512-j0AU8pW10LM8O68CTZ5QHnvOjSsnPICy0oQcP7zyM7eWkDQ/InkiQiirQKsPn1XRYDl4ccNu0WM582s3UKwcBg==}
+  '@xboxreplay/xboxlive-auth@5.1.0':
+    resolution: {integrity: sha512-UngHHsehZbiTjyyNmo8HvdoUDKMID1U9uVfrpFWUK/2UxPuVTKy5n+CzZQ3S488sW5vOhgh0lHqqynT8ouwgvw==}
+    engines: {node: '>=16.0.0'}
 
   '@xmcl/asm@1.0.1':
     resolution: {integrity: sha512-7vCVgm1E1IZ2cujiitFk9550Vgu2XAOn1ff90di638fMmTK0XkFMXKsSR/nGZmYKt+XiTMI/0B3TvreqbVjOug==}
@@ -3562,9 +3560,6 @@ packages:
 
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
-
-  axios@0.21.4:
-    resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
 
   axios@1.8.2:
     resolution: {integrity: sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==}
@@ -6168,13 +6163,13 @@ packages:
       mc-assets:
         optional: true
 
-  minecraft-protocol@https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/3fabf16c61995b7a2c6d4d2902f7af99d0fe0a77:
-    resolution: {tarball: https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/3fabf16c61995b7a2c6d4d2902f7af99d0fe0a77}
-    version: 1.66.0
+  minecraft-protocol@https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/1cb735a2b38edbd97e5f778a72275008a59276f1:
+    resolution: {tarball: https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/1cb735a2b38edbd97e5f778a72275008a59276f1}
+    version: 1.66.1
     engines: {node: '>=22'}
 
-  minecraft-renderer@0.1.37:
-    resolution: {integrity: sha512-QA+XIpo9aQ83BdhxTGrGwLmA0l9pSn8hAeHliMfDjENqk42DhyOC4LidXjLkeqvyCgQBaDwEmbgAyxBQMc0d5g==}
+  minecraft-renderer@0.1.40:
+    resolution: {integrity: sha512-HTaxVVEVGrCmtDsHeoyJqxEb4+noFtlY3zZ1blvWXVS5wMfM1GmQ1bZWfhnetBxaXYxIEBk3s/G5UOqVVOO1YQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       contro-max: '*'
@@ -6197,8 +6192,8 @@ packages:
     resolution: {integrity: sha512-31r73CqU7eiv8cQSVA+NMR0WfA8Qs+p6of+Bd7ApWzR4a56W6fgfY3MExNmxxbb1/w9IbxTcMhDbcoKmE/5+nw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/afebaa007ac86a02eba8e38bb2bdfb85487d9b8b:
-    resolution: {tarball: https://codeload.github.com/zardoy/mineflayer/tar.gz/afebaa007ac86a02eba8e38bb2bdfb85487d9b8b}
+  mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/6fe34e32c19657020cc48d95039e4b89361200b2:
+    resolution: {tarball: https://codeload.github.com/zardoy/mineflayer/tar.gz/6fe34e32c19657020cc48d95039e4b89361200b2}
     version: 8.0.0
     engines: {node: '>=22'}
 
@@ -6783,8 +6778,8 @@ packages:
     resolution: {integrity: sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==}
     engines: {node: '>= 0.8'}
 
-  prismarine-auth@2.7.0:
-    resolution: {integrity: sha512-L8wTF6sdtnN6hViPNy+Nx39a8iQBwR5iO92AWCiym5cSXp/92pmnuwnTdcmNDWyqq6zY4hbibVGYhgLA1Ox8sQ==}
+  prismarine-auth@3.1.1:
+    resolution: {integrity: sha512-NuNrMGZdoigFKsvi1ZZgAEvNYNuE5qe6lo/tw+bqeNbkhpjHC0u1JNxLEujnfqduXI18e19PvUtWNMDl/gH7yw==}
 
   prismarine-biome@1.3.0:
     resolution: {integrity: sha512-GY6nZxq93mTErT7jD7jt8YS1aPrOakbJHh39seYsJFXvueIOdHAmW16kYQVrTVMW5MlWLQVxV/EquRwOgr4MnQ==}
@@ -10483,7 +10478,7 @@ snapshots:
     dependencies:
       '@nxg-org/mineflayer-util-plugin': 1.8.4
       minecraft-data: 3.105.0
-      mineflayer: https://codeload.github.com/zardoy/mineflayer/tar.gz/afebaa007ac86a02eba8e38bb2bdfb85487d9b8b(encoding@0.1.13)
+      mineflayer: https://codeload.github.com/zardoy/mineflayer/tar.gz/6fe34e32c19657020cc48d95039e4b89361200b2(encoding@0.1.13)
       prismarine-block: https://codeload.github.com/zardoy/prismarine-block/tar.gz/401a296892fbde312ade34685fdc2db3d31668ad
       prismarine-item: 1.18.0
       prismarine-physics: https://codeload.github.com/zardoy/prismarine-physics/tar.gz/353e25b800149393f40539ec381218be44cbb03b
@@ -12153,14 +12148,7 @@ snapshots:
       loupe: 2.3.7
       pretty-format: 29.7.0
 
-  '@xboxreplay/errors@0.1.0': {}
-
-  '@xboxreplay/xboxlive-auth@3.3.3(debug@4.4.0)':
-    dependencies:
-      '@xboxreplay/errors': 0.1.0
-      axios: 0.21.4(debug@4.4.0)
-    transitivePeerDependencies:
-      - debug
+  '@xboxreplay/xboxlive-auth@5.1.0': {}
 
   '@xmcl/asm@1.0.1': {}
 
@@ -12229,7 +12217,7 @@ snapshots:
       long: 5.3.1
       mc-bridge: 0.1.3(minecraft-data@3.105.0)
       minecraft-data: 3.105.0
-      minecraft-protocol: https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/3fabf16c61995b7a2c6d4d2902f7af99d0fe0a77(patch_hash=a0fc92234601e93b1e536d8d7cc9bf80a9df670d821e1d12746f261d15954fae)(encoding@0.1.13)
+      minecraft-protocol: https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/1cb735a2b38edbd97e5f778a72275008a59276f1(patch_hash=a0fc92234601e93b1e536d8d7cc9bf80a9df670d821e1d12746f261d15954fae)(encoding@0.1.13)
       mkdirp: 2.1.6
       node-gzip: 1.1.2
       node-rsa: 1.1.1
@@ -12266,7 +12254,7 @@ snapshots:
       flatmap: 0.0.3
       long: 5.3.1
       minecraft-data: 3.105.0
-      minecraft-protocol: https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/3fabf16c61995b7a2c6d4d2902f7af99d0fe0a77(patch_hash=a0fc92234601e93b1e536d8d7cc9bf80a9df670d821e1d12746f261d15954fae)(encoding@0.1.13)
+      minecraft-protocol: https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/1cb735a2b38edbd97e5f778a72275008a59276f1(patch_hash=a0fc92234601e93b1e536d8d7cc9bf80a9df670d821e1d12746f261d15954fae)(encoding@0.1.13)
       mkdirp: 2.1.6
       node-gzip: 1.1.2
       node-rsa: 1.1.1
@@ -12548,12 +12536,6 @@ snapshots:
 
   aws4@1.13.2:
     optional: true
-
-  axios@0.21.4(debug@4.4.0):
-    dependencies:
-      follow-redirects: 1.15.9(debug@4.4.0)
-    transitivePeerDependencies:
-      - debug
 
   axios@1.8.2(debug@4.4.0):
     dependencies:
@@ -15522,12 +15504,12 @@ snapshots:
     dependencies:
       minecraft-data: 3.105.0
 
-  mcraft-fun-mineflayer@0.1.23(encoding@0.1.13)(mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/afebaa007ac86a02eba8e38bb2bdfb85487d9b8b(encoding@0.1.13)):
+  mcraft-fun-mineflayer@0.1.23(encoding@0.1.13)(mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/6fe34e32c19657020cc48d95039e4b89361200b2(encoding@0.1.13)):
     dependencies:
       '@zardoy/flying-squid': 0.0.49(encoding@0.1.13)
       exit-hook: 2.2.1
-      minecraft-protocol: https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/3fabf16c61995b7a2c6d4d2902f7af99d0fe0a77(patch_hash=a0fc92234601e93b1e536d8d7cc9bf80a9df670d821e1d12746f261d15954fae)(encoding@0.1.13)
-      mineflayer: https://codeload.github.com/zardoy/mineflayer/tar.gz/afebaa007ac86a02eba8e38bb2bdfb85487d9b8b(encoding@0.1.13)
+      minecraft-protocol: https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/1cb735a2b38edbd97e5f778a72275008a59276f1(patch_hash=a0fc92234601e93b1e536d8d7cc9bf80a9df670d821e1d12746f261d15954fae)(encoding@0.1.13)
+      mineflayer: https://codeload.github.com/zardoy/mineflayer/tar.gz/6fe34e32c19657020cc48d95039e4b89361200b2(encoding@0.1.13)
       prismarine-item: 1.18.0
       ws: 8.18.1
     transitivePeerDependencies:
@@ -15819,7 +15801,7 @@ snapshots:
     optionalDependencies:
       mc-assets: 0.2.72
 
-  minecraft-protocol@https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/3fabf16c61995b7a2c6d4d2902f7af99d0fe0a77(patch_hash=a0fc92234601e93b1e536d8d7cc9bf80a9df670d821e1d12746f261d15954fae)(encoding@0.1.13):
+  minecraft-protocol@https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/1cb735a2b38edbd97e5f778a72275008a59276f1(patch_hash=a0fc92234601e93b1e536d8d7cc9bf80a9df670d821e1d12746f261d15954fae)(encoding@0.1.13):
     dependencies:
       '@types/node-rsa': 1.1.4
       '@types/readable-stream': 4.0.18
@@ -15832,7 +15814,7 @@ snapshots:
       minecraft-folder-path: 1.2.0
       node-fetch: 2.7.0(encoding@0.1.13)
       node-rsa: 0.4.2
-      prismarine-auth: 2.7.0
+      prismarine-auth: 3.1.1
       prismarine-chat: 1.11.0
       prismarine-nbt: 2.7.0
       prismarine-realms: 1.3.2(encoding@0.1.13)
@@ -15844,7 +15826,7 @@ snapshots:
       - encoding
       - supports-color
 
-  minecraft-renderer@0.1.37(@types/react@18.3.18)(contro-max@0.1.12(typescript@5.5.4))(mc-assets@0.2.72)(minecraft-data@3.105.0)(react@18.3.1)(three@0.154.0):
+  minecraft-renderer@0.1.40(@types/react@18.3.18)(contro-max@0.1.12(typescript@5.5.4))(mc-assets@0.2.72)(minecraft-data@3.105.0)(react@18.3.1)(three@0.154.0):
     dependencies:
       '@tweenjs/tween.js': 20.0.3
       '@types/events': 3.0.3
@@ -15876,7 +15858,7 @@ snapshots:
 
   mineflayer-item-map-downloader@https://codeload.github.com/zardoy/mineflayer-item-map-downloader/tar.gz/a8d210ecdcf78dd082fa149a96e1612cc9747824(patch_hash=a731ebbace2d8790c973ab3a5ba33494a6e9658533a9710dd8ba36f86db061ad)(encoding@0.1.13):
     dependencies:
-      mineflayer: https://codeload.github.com/zardoy/mineflayer/tar.gz/afebaa007ac86a02eba8e38bb2bdfb85487d9b8b(encoding@0.1.13)
+      mineflayer: https://codeload.github.com/zardoy/mineflayer/tar.gz/6fe34e32c19657020cc48d95039e4b89361200b2(encoding@0.1.13)
       sharp: 0.30.7
     transitivePeerDependencies:
       - encoding
@@ -15891,11 +15873,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/afebaa007ac86a02eba8e38bb2bdfb85487d9b8b(encoding@0.1.13):
+  mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/6fe34e32c19657020cc48d95039e4b89361200b2(encoding@0.1.13):
     dependencies:
       '@nxg-org/mineflayer-physics-util': 1.8.19
       minecraft-data: 3.105.0
-      minecraft-protocol: https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/3fabf16c61995b7a2c6d4d2902f7af99d0fe0a77(patch_hash=a0fc92234601e93b1e536d8d7cc9bf80a9df670d821e1d12746f261d15954fae)(encoding@0.1.13)
+      minecraft-protocol: https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/1cb735a2b38edbd97e5f778a72275008a59276f1(patch_hash=a0fc92234601e93b1e536d8d7cc9bf80a9df670d821e1d12746f261d15954fae)(encoding@0.1.13)
       mojangson: 2.0.4
       prismarine-biome: 1.3.0(minecraft-data@3.105.0)(prismarine-registry@1.11.0)
       prismarine-block: https://codeload.github.com/zardoy/prismarine-block/tar.gz/401a296892fbde312ade34685fdc2db3d31668ad
@@ -16516,11 +16498,11 @@ snapshots:
 
   pretty-hrtime@1.0.3: {}
 
-  prismarine-auth@2.7.0:
+  prismarine-auth@3.1.1:
     dependencies:
       '@azure/msal-node': 2.16.2
-      '@xboxreplay/xboxlive-auth': 3.3.3(debug@4.4.0)
-      debug: 4.4.0(supports-color@8.1.1)
+      '@xboxreplay/xboxlive-auth': 5.1.0
+      debug: 4.4.3
       smart-buffer: 4.2.0
       uuid-1345: 1.0.2
     transitivePeerDependencies:

--- a/src/defaultOptions.ts
+++ b/src/defaultOptions.ts
@@ -41,7 +41,8 @@ export const defaultOptions = {
   loadPlayerSkins: true,
   renderEars: true,
   wasmExperimentalMesher: true,
-  worldPerformance: 'normal' as 'low-energy' | 'normal' | 'maximum',
+  rendererWorldPerformance: 'normal' as 'low-energy' | 'normal' | 'maximum',
+  rendererMeshersCountOverride: null as number | null,
   starfieldRendering: true,
   defaultSkybox: true,
   enabledResourcepack: null as string | null,
@@ -277,7 +278,7 @@ export const optionsMeta: Partial<Record<keyof typeof defaultOptions, OptionMeta
       ['no-buffers', 'No Buffers']
     ]
   },
-  worldPerformance: {
+  rendererWorldPerformance: {
     possibleValues: [
       ['low-energy', 'Low Energy'],
       ['normal', 'Normal'],

--- a/src/defaultOptions.ts
+++ b/src/defaultOptions.ts
@@ -41,7 +41,7 @@ export const defaultOptions = {
   loadPlayerSkins: true,
   renderEars: true,
   wasmExperimentalMesher: true,
-  lowMemoryMode: false,
+  worldPerformance: 'normal' as 'low-energy' | 'normal' | 'maximum',
   starfieldRendering: true,
   defaultSkybox: true,
   enabledResourcepack: null as string | null,
@@ -88,7 +88,6 @@ export const defaultOptions = {
   alwaysShowMobileControls: false,
   excludeCommunicationDebugEvents: [] as string[],
   preventDevReloadWhilePlaying: false,
-  numWorkers: 4,
   localServerOptions: {
     gameMode: 1
   } as any,
@@ -276,6 +275,13 @@ export const optionsMeta: Partial<Record<keyof typeof defaultOptions, OptionMeta
     possibleValues: [
       ['all', 'All'],
       ['no-buffers', 'No Buffers']
+    ]
+  },
+  worldPerformance: {
+    possibleValues: [
+      ['low-energy', 'Low Energy'],
+      ['normal', 'Normal'],
+      ['maximum', 'Maximum'],
     ]
   },
   // Custom string inputs (will use showInputsModal)

--- a/src/optionsGuiScheme.tsx
+++ b/src/optionsGuiScheme.tsx
@@ -131,9 +131,10 @@ export const guiOptionsScheme: {
       wasmExperimentalMesher: {
         text: 'WASM Mesher (Experimental)',
       },
-      lowMemoryMode: {
-        text: 'Low Memory Mode',
-        enableWarning: 'Enabling it will make chunks load ~4x slower. When in the game, app needs to be reloaded to apply this setting.',
+      worldPerformance: {
+        text: 'World Performance',
+        tooltip: 'Controls how many background workers process chunk geometry. Requires app reload to apply.',
+        requiresRestart: true,
       },
       starfieldRendering: {},
       renderEntities: {},

--- a/src/optionsGuiScheme.tsx
+++ b/src/optionsGuiScheme.tsx
@@ -116,6 +116,11 @@ export const guiOptionsScheme: {
       vanillaLook: {
         tooltip: 'On: Minecraft-style face shading. Off: client’s higher-contrast shading (default).',
       },
+      rendererWorldPerformance: {
+        text: 'World Performance',
+        tooltip: 'Controls how many background workers process chunk geometry. Requires app reload to apply.',
+        requiresRestart: true,
+      },
     },
     {
       custom () {
@@ -130,11 +135,6 @@ export const guiOptionsScheme: {
       },
       wasmExperimentalMesher: {
         text: 'WASM Mesher (Experimental)',
-      },
-      worldPerformance: {
-        text: 'World Performance',
-        tooltip: 'Controls how many background workers process chunk geometry. Requires app reload to apply.',
-        requiresRestart: true,
       },
       starfieldRendering: {},
       renderEntities: {},

--- a/src/optionsStorage.ts
+++ b/src/optionsStorage.ts
@@ -44,31 +44,11 @@ const migrateOptions = (options: Partial<AppOptions & Record<string, any>>) => {
     options.touchInteractionType = 'buttons'
   }
   if (options.lowMemoryMode) {
-    options.worldPerformance = 'low-energy'
+    options.rendererWorldPerformance = 'low-energy'
     delete options.lowMemoryMode
-  }
-  if ('numWorkers' in options) {
-    delete options.numWorkers
   }
 
   return options
-}
-const migrateOptionsLocalStorage = () => {
-  if (Object.keys(appStorage['options'] ?? {}).length) {
-    for (const key of Object.keys(appStorage['options'])) {
-      if (key === 'lowMemoryMode' && appStorage['options'][key]) {
-        appStorage.changedSettings.worldPerformance = 'low-energy'
-        continue
-      }
-      if (key === 'numWorkers') continue
-      if (!(key in defaultOptions)) continue // drop unknown options
-      const defaultValue = defaultOptions[key]
-      if (JSON.stringify(defaultValue) !== JSON.stringify(appStorage['options'][key])) {
-        appStorage.changedSettings[key] = appStorage['options'][key]
-      }
-    }
-    delete appStorage['options']
-  }
 }
 
 export type AppOptions = typeof defaultOptions
@@ -94,7 +74,6 @@ export const getChangedSettings = () => {
   )
 }
 
-migrateOptionsLocalStorage()
 export const options: AppOptions = proxy({
   ...defaultOptions,
   ...initialAppConfig.defaultSettings,

--- a/src/optionsStorage.ts
+++ b/src/optionsStorage.ts
@@ -43,12 +43,24 @@ const migrateOptions = (options: Partial<AppOptions & Record<string, any>>) => {
   if (options.touchControlsType === 'joystick-buttons') {
     options.touchInteractionType = 'buttons'
   }
+  if (options.lowMemoryMode) {
+    options.worldPerformance = 'low-energy'
+    delete options.lowMemoryMode
+  }
+  if ('numWorkers' in options) {
+    delete options.numWorkers
+  }
 
   return options
 }
 const migrateOptionsLocalStorage = () => {
   if (Object.keys(appStorage['options'] ?? {}).length) {
     for (const key of Object.keys(appStorage['options'])) {
+      if (key === 'lowMemoryMode' && appStorage['options'][key]) {
+        appStorage.changedSettings.worldPerformance = 'low-energy'
+        continue
+      }
+      if (key === 'numWorkers') continue
       if (!(key in defaultOptions)) continue // drop unknown options
       const defaultValue = defaultOptions[key]
       if (JSON.stringify(defaultValue) !== JSON.stringify(appStorage['options'][key])) {

--- a/src/watchOptions.ts
+++ b/src/watchOptions.ts
@@ -39,18 +39,22 @@ export const watchOptionsAfterViewerInit = () => {
 
   watchValue(options, o => {
     const wasmActive = o.wasmExperimentalMesher
-    switch (o.worldPerformance) {
+    const mesherWorkersOverride = o.rendererMeshersCountOverride
+    const applyMesherWorkers = (workers: number) => {
+      appViewer.inWorldRenderingConfig.mesherWorkers = mesherWorkersOverride ?? workers
+    }
+    switch (o.rendererWorldPerformance) {
       case 'low-energy':
-        appViewer.inWorldRenderingConfig.mesherWorkers = 1
+        applyMesherWorkers(1)
         appViewer.inWorldRenderingConfig.dedicatedChangeWorker = false
         break
       case 'normal':
-        appViewer.inWorldRenderingConfig.mesherWorkers = 3
+        applyMesherWorkers(2)
         appViewer.inWorldRenderingConfig.dedicatedChangeWorker = !wasmActive
         break
       case 'maximum':
-        appViewer.inWorldRenderingConfig.mesherWorkers = Math.max(4, Math.min(navigator.hardwareConcurrency ?? 4, 8))
-        appViewer.inWorldRenderingConfig.dedicatedChangeWorker = false
+        applyMesherWorkers(Math.max(3, Math.min(navigator.hardwareConcurrency ?? 0, 8)))
+        appViewer.inWorldRenderingConfig.dedicatedChangeWorker = !wasmActive
         break
     }
   })

--- a/src/watchOptions.ts
+++ b/src/watchOptions.ts
@@ -38,7 +38,21 @@ export const watchOptionsAfterViewerInit = () => {
   })
 
   watchValue(options, o => {
-    appViewer.inWorldRenderingConfig.mesherWorkers = o.lowMemoryMode ? 1 : o.numWorkers
+    const wasmActive = o.wasmExperimentalMesher
+    switch (o.worldPerformance) {
+      case 'low-energy':
+        appViewer.inWorldRenderingConfig.mesherWorkers = 1
+        appViewer.inWorldRenderingConfig.dedicatedChangeWorker = false
+        break
+      case 'normal':
+        appViewer.inWorldRenderingConfig.mesherWorkers = 3
+        appViewer.inWorldRenderingConfig.dedicatedChangeWorker = !wasmActive
+        break
+      case 'maximum':
+        appViewer.inWorldRenderingConfig.mesherWorkers = Math.max(4, Math.min(navigator.hardwareConcurrency ?? 4, 8))
+        appViewer.inWorldRenderingConfig.dedicatedChangeWorker = false
+        break
+    }
   })
 
   watchValue(options, o => {


### PR DESCRIPTION
## Summary
Replace `lowMemoryMode` boolean with `worldPerformance` enum setting.

## What
- Add `worldPerformance` option with three levels:
  `low-energy` (1 worker), `normal` (3 workers, dedicated change),
  `maximum` (4–8 workers based on hardwareConcurrency)
- Remove `lowMemoryMode` toggle and hidden `numWorkers` setting
- Migrate old `lowMemoryMode: true` → `worldPerformance: 'low-energy'`
  in both `migrateOptions` and `migrateOptionsLocalStorage`
- Update `watchOptions` to compute `mesherWorkers` and
  `dedicatedChangeWorker` from the selected performance level
- Disable `dedicatedChangeWorker` when WASM mesher is active
- Show "World Performance" in Settings → Render → Experimental
  with `requiresRestart` flag

## Why
The old binary toggle (1 vs 4 workers) had no middle ground.
The new 3-level setting gives users a balanced "Normal" mode
with dedicated change worker for responsive block updates,
plus battery-saving and maximum-performance extremes.