### PR TITLE
FIX(microsoftAuthflow) buffer partial chunks and stream-decode

### DIFF
--- a/src/microsoftAuthflow.ts
+++ b/src/microsoftAuthflow.ts
@@ -73,12 +73,23 @@ export default async ({ tokenCaches, proxyBaseUrl, setProgressText = (text) => {
 
           const processText = ({ done, value = undefined as Uint8Array | undefined }) => {
             if (done) {
+              // End-of-stream: flush TextDecoder's internal buffer (any
+              // incomplete UTF-8 sequence held by { stream: true }) and
+              // process the final event if it wasn't terminated by \n\n.
+              // Without this the last { token } / { newCache } update can
+              // be dropped when the server flushes the tail event without
+              // a closing delimiter.
+              buffer += decoder.decode()
+              const finalParts = buffer.split('\n\n')
+              buffer = finalParts.pop() ?? ''
+              for (const chunk of finalParts) processChunk(chunk)
+              if (buffer.trim()) processChunk(buffer)
               return
             }
 
             buffer += decoder.decode(value, { stream: true })
             const parts = buffer.split('\n\n')
-            buffer = parts.pop()!
+            buffer = parts.pop() ?? ''
 
             for (const chunk of parts) {
               processChunk(chunk)

--- a/src/microsoftAuthflow.ts
+++ b/src/microsoftAuthflow.ts
@@ -55,30 +55,32 @@ export default async ({ tokenCaches, proxyBaseUrl, setProgressText = (text) => {
 
           const reader = response.body!.getReader()
           const decoder = new TextDecoder('utf8')
+          let buffer = ''
+
+          const processChunk = (chunkStr) => {
+            let json: any
+            try {
+              json = JSON.parse(chunkStr)
+            } catch (err) {}
+            if (!json) return
+            if (json.user_code) {
+              onMsaCodeCallback(json)
+            }
+            if (json.error) throw new Error(`Auth server error: ${json.error}`)
+            if (json.token) result = json
+            if (json.newCache) setCacheResult(json.newCache)
+          }
 
           const processText = ({ done, value = undefined as Uint8Array | undefined }) => {
             if (done) {
               return
             }
 
-            const processChunk = (chunkStr) => {
-              let json: any
-              try {
-                json = JSON.parse(chunkStr)
-              } catch (err) {}
-              if (!json) return
-              if (json.user_code) {
-                onMsaCodeCallback(json)
-                // this.codeCallback(json)
-              }
-              if (json.error) throw new Error(`Auth server error: ${json.error}`)
-              if (json.token) result = json
-              if (json.newCache) setCacheResult(json.newCache)
-            }
+            buffer += decoder.decode(value, { stream: true })
+            const parts = buffer.split('\n\n')
+            buffer = parts.pop()!
 
-            const strings = decoder.decode(value)
-
-            for (const chunk of strings.split('\n\n')) {
+            for (const chunk of parts) {
               processChunk(chunk)
             }
 


### PR DESCRIPTION
The device-code stream reader had two protocol-handling defects:

1. TextDecoder.decode(value) was called without { stream: true }, so UTF-8 sequences split across network chunks were corrupted into replacement characters.

2. Events delimited by \n\n that arrived mid-network-chunk were silently lost: the trailing partial JSON failed JSON.parse, was swallowed by the surrounding try/catch, and never retried.

Hoist processChunk out of processText (no need to redefine per chunk), buffer across reads, split on \n\n with the tail kept for the next iteration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of Microsoft authentication so streamed responses (verification codes and tokens) are processed reliably across transmission edge cases, reducing intermittent failures and ensuring completed codes/tokens are delivered and applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zardoy/minecraft-web-client/pull/557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->