### PR TITLE
fix: adapt chunksLoaded/heightmaps to Record API from renderer

### DIFF
--- a/src/app/progressControllers.ts
+++ b/src/app/progressControllers.ts
@@ -18,7 +18,7 @@ const loadingChunksProgress = () => {
       const chunksTotal = appViewer.nonReactiveState.world.chunksTotalNumber
       if (chunksTotal === 0) return
 
-      const currentChunksLoaded = appViewer.rendererState.world.chunksLoaded.size
+      const currentChunksLoaded = Object.keys(appViewer.rendererState.world.chunksLoaded).length
 
       const deleteProgress = () => {
         setNotificationProgress('loadingChunks', {

--- a/src/index.ts
+++ b/src/index.ts
@@ -779,7 +779,7 @@ export async function connect (connectOptions: ConnectOptions) {
           resolve()
           unsub()
         } else {
-          const perc = Math.round(appViewer.rendererState.world.chunksLoaded.size / appViewer.nonReactiveState.world.chunksTotalNumber * 100)
+          const perc = Math.round(Object.keys(appViewer.rendererState.world.chunksLoaded).length / appViewer.nonReactiveState.world.chunksTotalNumber * 100)
           progress?.reportProgress('chunks', perc / 100)
         }
       })

--- a/src/react/MinimapProvider.tsx
+++ b/src/react/MinimapProvider.tsx
@@ -121,7 +121,7 @@ export class DrawerAdapterImpl extends TypedEventEmitter<MapUpdates> implements 
 
     subscribe(appViewer.rendererState.world, () => {
       for (const key of this.loadingChunksQueue) {
-        if (appViewer.rendererState.world.chunksLoaded.has(key)) {
+        if (appViewer.rendererState.world.chunksLoaded[key]) {
           this.loadingChunksQueue.delete(key)
           void this.loadChunk(key)
         }
@@ -205,9 +205,9 @@ export class DrawerAdapterImpl extends TypedEventEmitter<MapUpdates> implements 
     const [chunkX, chunkZ] = key.split(',').map(Number)
     const chunkWorldX = chunkX * 16
     const chunkWorldZ = chunkZ * 16
-    if (appViewer.rendererState.world.chunksLoaded.has(key)) {
+    if (appViewer.rendererState.world.chunksLoaded[key]) {
       // console.log('[MinimapProvider] loading chunk for minimap', key)
-      const heightmap = appViewer.rendererState.world.heightmaps.get(key)
+      const heightmap = appViewer.rendererState.world.heightmaps[key]
       if (heightmap) {
         // console.log('[MinimapProvider] did get highest blocks')
       } else {
@@ -338,7 +338,7 @@ export class DrawerAdapterImpl extends TypedEventEmitter<MapUpdates> implements 
     const chunkWorldX = chunkX * 16
     const chunkWorldZ = chunkZ * 16
     const highestBlocks = await getThreeJsRendererMethods()?.getHighestBlocks(`${chunkWorldX},${chunkWorldZ}`)
-    if (appViewer.rendererState.world.chunksLoaded.has(`${chunkWorldX},${chunkWorldZ}`)) {
+    if (appViewer.rendererState.world.chunksLoaded[`${chunkWorldX},${chunkWorldZ}`]) {
       const heightmap = new Uint8Array(256)
       const colors = Array.from({ length: 256 }).fill('') as string[]
       if (!highestBlocks) return null


### PR DESCRIPTION
### Adapt to renderer Record API

Follows the renderer change that drops Set/Map from `rendererState` in favor of
plain `Record`s (fixes the off-thread sync FPS→0 stall).

Migrates all consumers:
- `chunksLoaded.size` → `Object.keys(chunksLoaded).length`
  (`progressControllers.ts`, `index.ts`)
- `chunksLoaded.has(k)` → `chunksLoaded[k]`, `heightmaps.get(k)` →
  `heightmaps[k]` (`MinimapProvider.tsx`)

Verified no remaining Set/Map API usage on these fields, and the client never
touched `nonReactiveState.world.chunksLoaded` (now `chunksLoadedCount`), so no
other call sites are affected. Pure adaptation, no behavior change on the client.

Depends on the renderer [PR #28](https://github.com/zardoy/minecraft-renderer/pull/28)