### PR TITLE
fix chat(1)

### DIFF
--- a/src/react/ChatProvider.tsx
+++ b/src/react/ChatProvider.tsx
@@ -153,8 +153,8 @@ const ChatProviderBase = () => {
       })
     })
   }, [])
-
-  const disabledReason = disconnectedCleanup ? 'You have been disconnected from the server on ' + new Date(disconnectedCleanup.date).toLocaleString() : undefined
+const isConnected = bot && bot.entity && !disconnectedCleanup?.wasConnected
+const disabledReason = !isConnected && disconnectedCleanup ? 'You have been disconnected from the server on ' + new Date(disconnectedCleanup.date).toLocaleString() : undefined
 
   return <>
     <Chat

--- a/src/react/ChatProvider.tsx
+++ b/src/react/ChatProvider.tsx
@@ -152,7 +152,7 @@ const ChatProviderBase = () => {
       })
     })
   }, [])
-  const disabledReason = disconnectedCleanup ?.wasConnected === false ? 'You have been disconnected from the server on ' + new Date(disconnectedCleanup.date).toLocaleString() : undefined;
+  const disabledReason = disconnectedCleanup ?.wasConnected === false ? 'You have been disconnected from the server on ' + new Date(disconnectedCleanup.date).toLocaleString() : undefined
   return <>
     <Chat
       chatVanillaRestrictions={chatVanillaRestrictions}

--- a/src/react/ChatProvider.tsx
+++ b/src/react/ChatProvider.tsx
@@ -21,7 +21,7 @@ const TypingIndicatorOverlay = () => {
   const typingIndicatorText = useTypingIndicatorText()
   if (!typingIndicatorText) return null
 
-  return <div style={{
+ return <div style={{
     position: 'fixed',
     /* Above hotbar (~50px). Same vertical zone as chat messages (bottom: 40px) */
     bottom: 'calc(27px + env(safe-area-inset-bottom, 0px))',

--- a/src/react/ChatProvider.tsx
+++ b/src/react/ChatProvider.tsx
@@ -20,7 +20,7 @@ import { useTypingIndicatorText } from './useTypingIndicatorText'
 const TypingIndicatorOverlay = () => {
   const typingIndicatorText = useTypingIndicatorText()
   if (!typingIndicatorText) return null
-    return <div style={{
+  return <div style={{
     position: 'fixed',
     /* Above hotbar (~50px). Same vertical zone as chat messages (bottom: 40px) */
     bottom: 'calc(27px + env(safe-area-inset-bottom, 0px))',
@@ -152,7 +152,7 @@ const ChatProviderBase = () => {
       })
     })
   }, [])
-    const disabledReason = disconnectedCleanup?.wasConnected === false? 'You have been disconnected from the server on ' + new Date(disconnectedCleanup.date).toLocaleString() : undefined
+  const disabledReason = disconnectedCleanup ?.wasConnected === false ? 'You have been disconnected from the server on ' + new Date(disconnectedCleanup.date).toLocaleString() : undefined;
   return <>
     <Chat
       chatVanillaRestrictions={chatVanillaRestrictions}

--- a/src/react/ChatProvider.tsx
+++ b/src/react/ChatProvider.tsx
@@ -152,7 +152,7 @@ const ChatProviderBase = () => {
       })
     })
   }, [])
-    const disabledReason = disconnectedCleanup ?.wasConnected === false ? 'You have been disconnected from the server on ' + new Date(disconnectedCleanup.date).toLocaleString() : undefined
+  const disabledReason = disconnectedCleanup ?.wasConnected === false ? 'You have been disconnected from the server on ' + new Date(disconnectedCleanup.date).toLocaleString() : undefined
     <Chat
       chatVanillaRestrictions={chatVanillaRestrictions}
       debugChatScroll={debugChatScroll}

--- a/src/react/ChatProvider.tsx
+++ b/src/react/ChatProvider.tsx
@@ -20,8 +20,7 @@ import { useTypingIndicatorText } from './useTypingIndicatorText'
 const TypingIndicatorOverlay = () => {
   const typingIndicatorText = useTypingIndicatorText()
   if (!typingIndicatorText) return null
-
- return <div style={{
+    return <div style={{
     position: 'fixed',
     /* Above hotbar (~50px). Same vertical zone as chat messages (bottom: 40px) */
     bottom: 'calc(27px + env(safe-area-inset-bottom, 0px))',
@@ -153,9 +152,7 @@ const ChatProviderBase = () => {
       })
     })
   }, [])
-const disabledReason = disconnectedCleanup?.wasConnected === false 
-  ? 'You have been disconnected from the server on ' + new Date(disconnectedCleanup.date).toLocaleString() 
-  : undefined
+    const disabledReason = disconnectedCleanup?.wasConnected === false? 'You have been disconnected from the server on ' + new Date(disconnectedCleanup.date).toLocaleString() : undefined
   return <>
     <Chat
       chatVanillaRestrictions={chatVanillaRestrictions}

--- a/src/react/ChatProvider.tsx
+++ b/src/react/ChatProvider.tsx
@@ -20,6 +20,7 @@ import { useTypingIndicatorText } from './useTypingIndicatorText'
 const TypingIndicatorOverlay = () => {
   const typingIndicatorText = useTypingIndicatorText()
   if (!typingIndicatorText) return null
+
   return <div style={{
     position: 'fixed',
     /* Above hotbar (~50px). Same vertical zone as chat messages (bottom: 40px) */
@@ -153,6 +154,7 @@ const ChatProviderBase = () => {
     })
   }, [])
   const disabledReason = disconnectedCleanup ?.wasConnected === false ? 'You have been disconnected from the server on ' + new Date(disconnectedCleanup.date).toLocaleString() : undefined
+  return <>
     <Chat
       chatVanillaRestrictions={chatVanillaRestrictions}
       debugChatScroll={debugChatScroll}

--- a/src/react/ChatProvider.tsx
+++ b/src/react/ChatProvider.tsx
@@ -153,9 +153,9 @@ const ChatProviderBase = () => {
       })
     })
   }, [])
-const isConnected = bot && bot.entity && !disconnectedCleanup?.wasConnected
-const disabledReason = !isConnected && disconnectedCleanup ? 'You have been disconnected from the server on ' + new Date(disconnectedCleanup.date).toLocaleString() : undefined
-
+const disabledReason = disconnectedCleanup?.wasConnected === false 
+  ? 'You have been disconnected from the server on ' + new Date(disconnectedCleanup.date).toLocaleString() 
+  : undefined
   return <>
     <Chat
       chatVanillaRestrictions={chatVanillaRestrictions}

--- a/src/react/ChatProvider.tsx
+++ b/src/react/ChatProvider.tsx
@@ -152,8 +152,7 @@ const ChatProviderBase = () => {
       })
     })
   }, [])
-  const disabledReason = disconnectedCleanup ?.wasConnected === false ? 'You have been disconnected from the server on ' + new Date(disconnectedCleanup.date).toLocaleString() : undefined
-  return <>
+    const disabledReason = disconnectedCleanup ?.wasConnected === false ? 'You have been disconnected from the server on ' + new Date(disconnectedCleanup.date).toLocaleString() : undefined
     <Chat
       chatVanillaRestrictions={chatVanillaRestrictions}
       debugChatScroll={debugChatScroll}


### PR DESCRIPTION
Fix: Allow chat commands when connected to server
## Problem
Chat commands (like `/clan resign`, `/clan`, etc.) were showing "Chat disabled in client options" error even when connected to the server.

## Root Cause
The `disconnectedCleanup` state was being checked incorrectly, disabling chat input even when the player was actively connected.

## Solution
Added proper boolean check to `disconnectedCleanup.wasConnected` flag to ensure chat is only disabled when truly disconnected from the server.

## Testing
- Tested with `/clan` commands while connected to server
- Chat input should now work properly
- Disconnect message should only appear when actually disconnected

## Files Changed
- `src/react/ChatProvider.tsx` - Fixed chat disabled condition check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined chat input disabling logic during disconnects so the “disconnected” state is shown only after a prior successful connection, preventing incorrect disabled messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->