### PR TITLE
fix: remove dying mobs immediately on death

### DIFF
--- a/src/appViewer.ts
+++ b/src/appViewer.ts
@@ -100,6 +100,7 @@ const pendingUpdateLightRelight = new Set<string>()
 
 const connectAppWorldViewToBot = () => {
   const entitiesObjectData = new Map<string, number>()
+  const deadEntities = new Set<number>()
   bot._client.prependListener('spawn_entity', (data) => {
     if (data.objectData && data.entityId !== undefined) {
       entitiesObjectData.set(data.entityId, data.objectData)
@@ -115,6 +116,7 @@ const connectAppWorldViewToBot = () => {
       return
     }
     if (!e.name) return // mineflayer received update for not spawned entity
+    if (deadEntities.has(e.id)) return
     e.objectData = entitiesObjectData.get(e.id)
     appViewer.worldView?.emit(name as any, {
       ...e,
@@ -140,7 +142,14 @@ const connectAppWorldViewToBot = () => {
     entityMoved (e: any) {
       emitEntity(e, 'entityMoved')
     },
+    entityDead (e: any) {
+      if (e === bot.entity) return
+      if (deadEntities.has(e.id)) return
+      deadEntities.add(e.id)
+      appViewer.worldView?.emit('entity', { id: e.id, delete: true })
+    },
     entityGone (e: any) {
+      deadEntities.delete(e.id)
       appViewer.worldView?.emit('entity', { id: e.id, delete: true })
     },
     chunkColumnLoad (pos: Vec3) {


### PR DESCRIPTION
## Remove dying mobs from the scene immediately

Fixes **zardoy/minecraft-renderer#45** — killed mobs no longer freeze in place
for ~1 second before disappearing.

### Root cause
When a mob dies, mineflayer emits `entityDead` (from the Entity Status "death"
packet) but **leaves the entity in the world** — it's only deleted on the later
`entity_destroy`/despawn packet, which is the only thing our bridge listened to.
So the dead mob sat frozen in the scene until despawn.

### Fix
In `connectAppWorldViewToBot`, subscribe to `entityDead` and remove the entity
right away (per the issue: no death animation needed, early removal is fine).
Uses mineflayer's high-level `entityDead` event so it works across protocol
versions. Added a small guard set so a stray entity update can't re-add the
corpse before the despawn packet arrives, cleaned up on `entityGone`.

The renderer needed no change — it already removes entities on an
`entity { delete: true }` event.

### Verification
Verified at runtime: killed mobs now disappear instantly on the killing blow and
do not reappear.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved entity lifecycle handling so deleted entities are no longer re-sent after being marked dead.
  - Reduced duplicate “entity dead” updates and ensured removed entities are cleared correctly before delete notifications are emitted.
  - Added safer handling for player-related entity death events to avoid unintended updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->