### PR TITLE
feat(debug): Smart Cull + Cave Cull Debug toggles

### DIFF
--- a/src/react/RendererDebugMenu.tsx
+++ b/src/react/RendererDebugMenu.tsx
@@ -14,7 +14,7 @@ export default () => {
 
 const RendererDebugMenu = ({ worldRenderer }: { worldRenderer: WorldRendererCommon }) => {
   const { reactiveDebugParams } = worldRenderer
-  const { chunksRenderAboveEnabled, chunksRenderBelowEnabled, chunksRenderDistanceEnabled, chunksRenderAboveOverride, chunksRenderBelowOverride, chunksRenderDistanceOverride, stopRendering, disableEntities } = useSnapshot(reactiveDebugParams)
+  const { chunksRenderAboveEnabled, chunksRenderBelowEnabled, chunksRenderDistanceEnabled, chunksRenderAboveOverride, chunksRenderBelowOverride, chunksRenderDistanceOverride, stopRendering, disableEntities, caveCullingDebug, smartCull } = useSnapshot(reactiveDebugParams)
 
   const { rendererPerfDebugOverlay } = useSnapshot(options)
 
@@ -35,6 +35,16 @@ const RendererDebugMenu = ({ worldRenderer }: { worldRenderer: WorldRendererComm
         label={disableEntities ? 'Enable Entities' : 'Disable Entities'}
         onClick={() => { reactiveDebugParams.disableEntities = !reactiveDebugParams.disableEntities }}
         overlayColor={disableEntities ? 'red' : undefined}
+      />
+      <Button
+        label={smartCull === false ? 'Enable Smart Cull' : 'Disable Smart Cull'}
+        onClick={() => { reactiveDebugParams.smartCull = smartCull === false ? true : false }}
+        overlayColor={smartCull === false ? 'orange' : undefined}
+      />
+      <Button
+        label={caveCullingDebug ? 'Hide Cave Cull Debug' : 'Show Cave Cull Debug'}
+        onClick={() => { reactiveDebugParams.caveCullingDebug = !reactiveDebugParams.caveCullingDebug }}
+        overlayColor={caveCullingDebug ? 'cyan' : undefined}
       />
     </div>
 


### PR DESCRIPTION
## Cave-culling debug toggles

Adds two buttons to the Renderer Debug menu, backed by
`minecraft-renderer`'s `reactiveDebugParams`:

- **Disable / Enable Smart Cull** — turns section occlusion (cave) culling on/off.
- **Show / Hide Cave Cull Debug** — tints section borders (red = culled,
  rainbow = visible by BFS step) to validate the culled volume.

Pairs with minecraft-renderer [PR #80](https://github.com/zardoy/minecraft-renderer/pull/80) ([issue #77](https://github.com/zardoy/minecraft-renderer/issues/77)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new rendering debug toggles for smart culling and cave culling debug in the in-app debug menu.
  * Improved visual feedback by updating overlay colors to match the current toggle state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->