### PR TITLE
fix(audio): forward per-sound attenuation distance and effective volume

### DIFF
--- a/scripts/prepareSounds.mjs
+++ b/scripts/prepareSounds.mjs
@@ -236,7 +236,7 @@ const writeSoundsMap = async () => {
       if (isNaN(minWeight)) debugger
       for (const sound of sounds) {
         if (sound.weight && isNaN(sound.weight)) debugger
-        outputUseSoundLine.push(`${sound.volume ?? 1};${sound.name};${sound.weight ?? minWeight}`)
+        outputUseSoundLine.push(`${sound.volume ?? 1};${sound.name};${sound.weight ?? minWeight};${sound.attenuation_distance ?? 16}`)
       }
       const id = mappingJson.sounds.findIndex(x => x === name)
       if (id === -1) {

--- a/src/sounds/botSoundSystem.ts
+++ b/src/sounds/botSoundSystem.ts
@@ -53,7 +53,8 @@ subscribeKey(miscUiState, 'gameLoaded', async () => {
           soundData.url,
           soundData.volume,
           Math.max(Math.min(pitch ?? 1, 2), 0.5),
-          soundData.timeout ?? options.remoteSoundsLoadTimeout
+          soundData.timeout ?? options.remoteSoundsLoadTimeout,
+          soundData.attenuationDistance
         )
       }
       if (getDistance(bot.entity.position, position) < 4 * 16) {

--- a/src/sounds/soundAttenuation.ts
+++ b/src/sounds/soundAttenuation.ts
@@ -1,0 +1,5 @@
+export const DEFAULT_ATTENUATION_DISTANCE = 16
+
+export function computeEffectiveVolume (soundEntryVolume: number, packetVolume: number): number {
+  return soundEntryVolume * Math.max(packetVolume, 0)
+}

--- a/src/sounds/soundMapFormat.ts
+++ b/src/sounds/soundMapFormat.ts
@@ -1,0 +1,25 @@
+import { DEFAULT_ATTENUATION_DISTANCE } from './soundAttenuation'
+
+export interface SoundEntry {
+  file: string
+  weight: number
+  volume: number
+  attenuationDistance: number
+}
+
+export function parseSoundMapVariant (packed: string): SoundEntry {
+  const [volume, name, weight, attenuationDistance] = packed.split(';')
+  if (isNaN(Number(volume))) throw new Error('volume is not a number')
+  if (isNaN(Number(weight))) throw new TypeError('weight is not a number')
+  if (attenuationDistance !== undefined && attenuationDistance !== '' && isNaN(Number(attenuationDistance))) {
+    throw new TypeError('attenuation distance is not a number')
+  }
+  return {
+    file: name,
+    weight: Number(weight),
+    volume: Number(volume),
+    attenuationDistance: attenuationDistance !== undefined && attenuationDistance !== ''
+      ? Number(attenuationDistance)
+      : DEFAULT_ATTENUATION_DISTANCE
+  }
+}

--- a/src/sounds/soundsMap.test.ts
+++ b/src/sounds/soundsMap.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import fs from 'fs'
+import { DEFAULT_ATTENUATION_DISTANCE } from './soundAttenuation'
+import { parseSoundMapVariant } from './soundMapFormat'
+
+vi.mock('../basicSounds', () => ({ stopAllSounds: vi.fn() }))
+vi.mock('./musicSystem', () => ({ musicSystem: { stopMusic: vi.fn(), playMusic: vi.fn() } }))
+
+import { SoundMap } from './soundsMap'
+
+describe('parseSoundMapVariant', () => {
+  it('parses legacy 3-field bundles with default attenuation distance', () => {
+    expect(parseSoundMapVariant('1;dig/stone1;1')).toEqual({
+      file: 'dig/stone1',
+      weight: 1,
+      volume: 1,
+      attenuationDistance: DEFAULT_ATTENUATION_DISTANCE
+    })
+  })
+
+  it('parses new 4-field bundles with explicit attenuation distance', () => {
+    expect(parseSoundMapVariant('12;block/bell/bell_use01;1;16')).toEqual({
+      file: 'block/bell/bell_use01',
+      weight: 1,
+      volume: 12,
+      attenuationDistance: 16
+    })
+    expect(parseSoundMapVariant('1;block/amethyst/resonate1;1;48')).toEqual({
+      file: 'block/amethyst/resonate1',
+      weight: 1,
+      volume: 1,
+      attenuationDistance: 48
+    })
+    expect(parseSoundMapVariant('1;block/beacon/activate;1;7')).toEqual({
+      file: 'block/beacon/activate',
+      weight: 1,
+      volume: 1,
+      attenuationDistance: 7
+    })
+  })
+})
+
+describe('SoundMap.getSoundUrl', () => {
+  const soundData = {
+    allSoundsMap: {
+      '1.21.4': {
+        '0;block.stone.break': '1;dig/stone1;1',
+        '1;block.bell.use': '12;block/bell/bell_use01;1;16',
+        '2;block.amethyst_block.resonate': '1;block/amethyst/resonate1;1;48',
+        '3;block.beacon.activate': '1;block/beacon/activate;1;7'
+      }
+    },
+    soundsLegacyMap: {},
+    soundsMeta: {
+      format: 'mp3',
+      baseUrl: 'https://example.com/sounds'
+    }
+  }
+
+  it('returns effective volume without upper clamp for bell-like entries', async () => {
+    const map = new SoundMap(soundData, '1.21.4')
+    const result = await map.getSoundUrl('block.bell.use', 2)
+    expect(result).toMatchObject({
+      volume: 24,
+      attenuationDistance: 16
+    })
+    expect(result?.url).toContain('block/bell/bell_use01.mp3')
+  })
+
+  it('keeps custom attenuation distance from packed bundle', async () => {
+    const map = new SoundMap(soundData, '1.21.4')
+    const result = await map.getSoundUrl('block.amethyst_block.resonate', 1)
+    expect(result).toMatchObject({
+      volume: 1,
+      attenuationDistance: 48
+    })
+  })
+
+  it('defaults attenuation distance for legacy bundle entries', async () => {
+    const map = new SoundMap(soundData, '1.21.4')
+    const result = await map.getSoundUrl('block.stone.break', 0.6)
+    expect(result).toMatchObject({
+      volume: 0.6,
+      attenuationDistance: DEFAULT_ATTENUATION_DISTANCE
+    })
+  })
+
+  it('reads attenuation_distance from resource-pack sounds.json', async () => {
+    const readFileSpy = vi.spyOn(fs.promises, 'readFile').mockImplementation(async (filePath) => {
+      if (String(filePath).endsWith('sounds.json')) {
+        return JSON.stringify({
+          'block.custom.sound': {
+            category: 'block',
+            sounds: [{
+              name: 'custom/sound',
+              volume: 1,
+              attenuation_distance: 7
+            }]
+          }
+        })
+      }
+      return Buffer.from('audio')
+    })
+    const map = new SoundMap(soundData, '1.21.4')
+    await map.updateActiveResourcePackBasePath('/resourcepack')
+
+    const result = await map.getSoundUrl('block.custom.sound', 1)
+    expect(result).toMatchObject({
+      volume: 1,
+      attenuationDistance: 7
+    })
+    readFileSpy.mockRestore()
+  })
+})

--- a/src/sounds/soundsMap.test.ts
+++ b/src/sounds/soundsMap.test.ts
@@ -1,12 +1,11 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
 import fs from 'fs'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { DEFAULT_ATTENUATION_DISTANCE } from './soundAttenuation'
 import { parseSoundMapVariant } from './soundMapFormat'
+import { SoundMap } from './soundsMap'
 
 vi.mock('../basicSounds', () => ({ stopAllSounds: vi.fn() }))
 vi.mock('./musicSystem', () => ({ musicSystem: { stopMusic: vi.fn(), playMusic: vi.fn() } }))
-
-import { SoundMap } from './soundsMap'
 
 describe('parseSoundMapVariant', () => {
   it('parses legacy 3-field bundles with default attenuation distance', () => {

--- a/src/sounds/soundsMap.ts
+++ b/src/sounds/soundsMap.ts
@@ -4,6 +4,8 @@ import { versionsMapToMajor, versionToMajor, versionToNumber } from 'minecraft-r
 
 import { stopAllSounds } from '../basicSounds'
 import { musicSystem } from './musicSystem'
+import { computeEffectiveVolume, DEFAULT_ATTENUATION_DISTANCE } from './soundAttenuation'
+import { parseSoundMapVariant, type SoundEntry } from './soundMapFormat'
 
 interface SoundMeta {
   format: string
@@ -25,17 +27,12 @@ interface BlockSoundMap {
   [blockName: string]: string
 }
 
-interface SoundEntry {
-  file: string
-  weight: number
-  volume: number
-}
-
 interface ResourcePackSoundEntry {
   name: string
   stream?: boolean
   volume?: number
   timeout?: number
+  attenuation_distance?: number
 }
 
 interface ResourcePackSound {
@@ -80,16 +77,7 @@ export class SoundMap {
     this.soundsPerName = {}
 
     for (const [id, soundsStr] of Object.entries(soundsMap)) {
-      const sounds = soundsStr.split(',').map(s => {
-        const [volume, name, weight] = s.split(';')
-        if (isNaN(Number(volume))) throw new Error('volume is not a number')
-        if (isNaN(Number(weight))) throw new TypeError('weight is not a number')
-        return {
-          file: name,
-          weight: Number(weight),
-          volume: Number(volume)
-        }
-      })
+      const sounds = soundsStr.split(',').map(s => parseSoundMapVariant(s))
 
       const [idPart, namePart] = id.split(';')
       this.soundsIdToName[idPart] = namePart
@@ -141,13 +129,16 @@ export class SoundMap {
     await scan(soundsBasePath)
   }
 
-  async getSoundUrl (soundKey: string, volume = 1): Promise<{ url: string; volume: number, timeout?: number } | undefined> {
+  async getSoundUrl (soundKey: string, volume = 1): Promise<{ url: string; volume: number; attenuationDistance: number; timeout?: number } | undefined> {
+    const effectiveVolume = (soundEntryVolume: number) => computeEffectiveVolume(soundEntryVolume, volume)
+
     // First check resource pack sounds.json
     if (this.activeResourcePackSoundsJson && soundKey in this.activeResourcePackSoundsJson) {
       const rpSound = this.activeResourcePackSoundsJson[soundKey]
       // Pick a random sound from the resource pack
       const sound = rpSound.sounds[Math.floor(Math.random() * rpSound.sounds.length)]
       const soundVolume = sound.volume ?? 1
+      const attenuationDistance = sound.attenuation_distance ?? DEFAULT_ATTENUATION_DISTANCE
 
       if (this.activeResourcePackBasePath) {
         const tryFormat = async (format: string) => {
@@ -155,7 +146,8 @@ export class SoundMap {
             if (sound.name.startsWith('http://') || sound.name.startsWith('https://')) {
               return {
                 url: sound.name,
-                volume: soundVolume * Math.max(Math.min(volume, 1), 0),
+                volume: effectiveVolume(soundVolume),
+                attenuationDistance,
                 timeout: sound.timeout
               }
             }
@@ -163,7 +155,8 @@ export class SoundMap {
             const fileData = await fs.promises.readFile(resourcePackPath)
             return {
               url: `data:audio/${format};base64,${fileData.toString('base64')}`,
-              volume: soundVolume * Math.max(Math.min(volume, 1), 0)
+              volume: effectiveVolume(soundVolume),
+              attenuationDistance
             }
           } catch (err) {
             return null
@@ -203,7 +196,8 @@ export class SoundMap {
 
     return {
       url,
-      volume: sound.volume * Math.max(Math.min(volume, 1), 0)
+      volume: effectiveVolume(sound.volume),
+      attenuationDistance: sound.attenuationDistance
     }
   }
 


### PR DESCRIPTION
Follow-up to the renderer attenuation fix. The client resolved a sound's URL and effective volume but discarded the per-sound attenuation distance and clamped packet volume too early. As a result, the renderer could not reproduce the audible range of loud vanilla sounds.

### Changes

* Include `attenuation_distance` when generating the bundled sound map.
* Parse both the new 4-field and existing 3-field sound-map formats, defaulting to `16` for legacy data.
* Read `attenuation_distance` from resource-pack `sounds.json` entries.
* Preserve packet volumes above `1` when computing effective volume.
* Forward effective volume and attenuation distance to `minecraft-renderer`.
* Add tests for legacy maps, explicit attenuation distances, loud sounds, and resource-pack metadata.

### Verification

Tested with the matching renderer change on Minecraft `1.17.1`:

* Ordinary block sounds fade correctly with both horizontal and vertical distance.
* All 6 targeted sound-map tests pass.

> Bundled per-sound attenuation values take effect after the generated sound map is regenerated and published. Existing bundles continue to use the default distance of `16`.

---

**Depends on the renderer change:** https://github.com/zardoy/minecraft-renderer/pull/83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable attenuation distances for sound variants, including resource-pack sounds.
  * Sound map parsing now supports both legacy (default attenuation) and new (explicit attenuation) formats.
  * Sound URL lookup and audio playback now carry attenuation distance through to the client.

* **Bug Fixes**
  * Improved effective volume calculation to avoid negative volume values and apply packet volume safely.

* **Tests**
  * Added coverage for legacy/new sound map formats and attenuation behavior across resource-pack loading and URL generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->