### PR TITLE
Update mouse.ts

### DIFF
--- a/src/mineflayer/plugins/mouse.ts
+++ b/src/mineflayer/plugins/mouse.ts
@@ -47,6 +47,7 @@ function cursorBlockDisplay (bot: Bot) {
 export default (bot: Bot) => {
   bot.loadPlugin(createMouse({
     useMineflayerInteractMethods: false,
+      blockPlacePrediction: false,
   }))
 
   domListeners(bot)

--- a/src/mineflayer/plugins/mouse.ts
+++ b/src/mineflayer/plugins/mouse.ts
@@ -47,7 +47,7 @@ function cursorBlockDisplay (bot: Bot) {
 export default (bot: Bot) => {
   bot.loadPlugin(createMouse({
     useMineflayerInteractMethods: false,
-  blockPlacePrediction: false,
+    blockPlacePrediction: false,
   }))
 
   domListeners(bot)

--- a/src/mineflayer/plugins/mouse.ts
+++ b/src/mineflayer/plugins/mouse.ts
@@ -47,7 +47,7 @@ function cursorBlockDisplay (bot: Bot) {
 export default (bot: Bot) => {
   bot.loadPlugin(createMouse({
     useMineflayerInteractMethods: false,
-      blockPlacePrediction: false,
+  blockPlacePrediction: false,
   }))
 
   domListeners(bot)


### PR DESCRIPTION
Root Cause
When right-clicking on blocks (like stone, crafting table), mineflayer-mouse's updatePlaceInteract method calls botTryPlaceBlockPrediction() which modifies the local world by immediately placing a predicted block. This local world modification triggers chunk re-meshing, which can create rendering artifacts that make blocks appear transparent (X-ray effect).

The issue affects:

Placeable blocks (stone, dirt, etc.) → prediction runs (modifies local world + block_place sent)
GUI blocks (crafting table, chest, etc.) → prediction skipped but block_place still sent
Non-placeable items (iron ingot) → prediction skipped + startUsingItem called (the item activation somehow avoids the artifact)
Built-in server (Flying Squid/mcrafter) → not affected because it handles the packet flow differently than real servers
Fix:
Added blockPlacePrediction: false to the mouse plugin configuration in src/mineflayer/plugins/mouse.ts:50.

This disables the client-side block placement prediction, preventing the local world from being preemptively modified on right-click. The block_place packet is still sent to the server as normal, so all gameplay functions (GUI interactions, block placement) continue to work through the standard server-authoritative flow.
And I tested it, it worked. 
i fix the error:https://github.com/zardoy/minecraft-web-client/issues/571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mouse interactions by disabling block placement prediction, reducing unintended or inaccurate block placement behavior.
* **Chores**
  * Updated mouse plugin initialization to use an explicit setting for more predictable interaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->