### PR TITLE
feat(boats): integrate controlled boat physics and rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "flying-squid": "npm:@zardoy/flying-squid@^0.0.122",
     "framer-motion": "^12.9.2",
     "fs-extra": "^11.1.1",
+    "glob": "^10.4.5",
     "google-drive-browserfs": "github:zardoy/browserfs#google-drive",
     "jszip": "^3.10.1",
     "lil-gui": "^0.21.0",
@@ -116,7 +117,8 @@
     "valtio": "^1.11.1",
     "vec3": "^0.1.7",
     "wait-on": "^7.2.0",
-    "workbox-build": "^7.0.0"
+    "workbox-build": "^7.0.0",
+    "ws": "^8.18.1"
   },
   "devDependencies": {
     "@rsbuild/core": "1.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       fs-extra:
         specifier: ^11.1.1
         version: 11.3.0
+      glob:
+        specifier: ^10.4.5
+        version: 10.4.5
       google-drive-browserfs:
         specifier: github:zardoy/browserfs#google-drive
         version: browserfs@https://codeload.github.com/zardoy/browserfs/tar.gz/ab58ae8ef00e3a31db01909e365e6cb5188436e0
@@ -254,6 +257,9 @@ importers:
       workbox-build:
         specifier: ^7.0.0
         version: 7.3.0(@types/babel__core@7.20.5)
+      ws:
+        specifier: ^8.18.1
+        version: 8.18.1
     devDependencies:
       '@rsbuild/core':
         specifier: 1.3.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1966,8 +1966,8 @@ packages:
   '@nxg-org/mineflayer-auto-jump@0.8.0':
     resolution: {integrity: sha512-LEI4Yz3LEbHJN1eHSDlK+bwaQ9p7Fs6kfHDnneODR78BzYKi8HJw0Zks5Vrr7KK90RrZutsGa19Jr7tBob9KCQ==}
 
-  '@nxg-org/mineflayer-physics-util@https://codeload.github.com/zardoy/mineflayer-physics-utils/tar.gz/978c51ea63a7532cddd4223ee387d5d07365d486':
-    resolution: {tarball: https://codeload.github.com/zardoy/mineflayer-physics-utils/tar.gz/978c51ea63a7532cddd4223ee387d5d07365d486}
+  '@nxg-org/mineflayer-physics-util@https://codeload.github.com/zardoy/mineflayer-physics-utils/tar.gz/ab0402efd01020e61a7b800cf89a1485b4df82d7':
+    resolution: {tarball: https://codeload.github.com/zardoy/mineflayer-physics-utils/tar.gz/ab0402efd01020e61a7b800cf89a1485b4df82d7}
     version: 1.9.10
 
   '@nxg-org/mineflayer-tracker@1.3.0':
@@ -10462,16 +10462,16 @@ snapshots:
 
   '@nxg-org/mineflayer-auto-jump@0.8.0':
     dependencies:
-      '@nxg-org/mineflayer-physics-util': https://codeload.github.com/zardoy/mineflayer-physics-utils/tar.gz/978c51ea63a7532cddd4223ee387d5d07365d486
+      '@nxg-org/mineflayer-physics-util': https://codeload.github.com/zardoy/mineflayer-physics-utils/tar.gz/ab0402efd01020e61a7b800cf89a1485b4df82d7
       strict-event-emitter-types: 2.0.0
 
-  '@nxg-org/mineflayer-physics-util@https://codeload.github.com/zardoy/mineflayer-physics-utils/tar.gz/978c51ea63a7532cddd4223ee387d5d07365d486':
+  '@nxg-org/mineflayer-physics-util@https://codeload.github.com/zardoy/mineflayer-physics-utils/tar.gz/ab0402efd01020e61a7b800cf89a1485b4df82d7':
     dependencies:
       '@nxg-org/mineflayer-util-plugin': 1.8.4
 
   '@nxg-org/mineflayer-tracker@1.3.0(encoding@0.1.13)':
     dependencies:
-      '@nxg-org/mineflayer-physics-util': https://codeload.github.com/zardoy/mineflayer-physics-utils/tar.gz/978c51ea63a7532cddd4223ee387d5d07365d486
+      '@nxg-org/mineflayer-physics-util': https://codeload.github.com/zardoy/mineflayer-physics-utils/tar.gz/ab0402efd01020e61a7b800cf89a1485b4df82d7
       '@nxg-org/mineflayer-trajectories': 1.2.0(encoding@0.1.13)
       '@nxg-org/mineflayer-util-plugin': 1.8.4
     transitivePeerDependencies:
@@ -15881,7 +15881,7 @@ snapshots:
 
   mineflayer@https://codeload.github.com/zardoy/mineflayer/tar.gz/5f9c9409700a1f48e781c9b7828b7494bcfb20bf(encoding@0.1.13):
     dependencies:
-      '@nxg-org/mineflayer-physics-util': https://codeload.github.com/zardoy/mineflayer-physics-utils/tar.gz/978c51ea63a7532cddd4223ee387d5d07365d486
+      '@nxg-org/mineflayer-physics-util': https://codeload.github.com/zardoy/mineflayer-physics-utils/tar.gz/ab0402efd01020e61a7b800cf89a1485b4df82d7
       minecraft-data: 3.105.0
       minecraft-protocol: https://codeload.github.com/PrismarineJS/node-minecraft-protocol/tar.gz/ee40987dde124cd2f560bb944cfffb29946fef81(patch_hash=a0fc92234601e93b1e536d8d7cc9bf80a9df670d821e1d12746f261d15954fae)(encoding@0.1.13)
       mojangson: 2.0.4

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -199,6 +199,7 @@ const appConfig = defineConfig({
             'process.env.COOKIE_STORAGE_PREFIX': JSON.stringify(process.env.COOKIE_STORAGE_PREFIX || ''),
             'process.env.WS_PORT': JSON.stringify(enableMetrics ? 8081 : false),
             'process.env.MINECRAFT_RENDERER_VERSION': JSON.stringify(minecraftRendererVersion),
+            'process.env.BOAT_PHYS_DEBUG': JSON.stringify(process.env.BOAT_PHYS_DEBUG),
         },
     },
     server: {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,7 +1,7 @@
 //@ts-check
 const fsExtra = require('fs-extra')
 const defaultLocalServerOptions = require('../src/defaultLocalServerOptions')
-const glob = require('glob')
+const { globSync } = require('glob')
 const fs = require('fs')
 const crypto = require('crypto')
 const path = require('path')
@@ -21,7 +21,7 @@ exports.copyFiles = (dev = false) => {
     if (!dev) {
         // copy glob
         const cwd = `${prismarineViewerBase}/public/textures/`
-        const files = glob.sync('*.png', { cwd: cwd, nodir: true, })
+        const files = globSync('*.png', { cwd: cwd, nodir: true, })
         for (const file of files) {
             const copyDest = path.join('dist/textures/', file)
             fs.mkdirSync(path.dirname(copyDest), { recursive: true, })
@@ -66,7 +66,7 @@ exports.getSwAdditionalEntries = () => {
     const output = []
     console.log('Generating sw additional entries...')
     for (const pattern of filesToCachePatterns) {
-        const files = glob.sync(pattern, { cwd: 'dist' })
+        const files = globSync(pattern, { cwd: 'dist' })
         for (const file of files) {
             const fullPath = path.join('dist', file)
             if (!fs.lstatSync(fullPath).isFile()) continue

--- a/src/appViewer.ts
+++ b/src/appViewer.ts
@@ -137,6 +137,23 @@ const connectAppWorldViewToBot = () => {
     })
   }
 
+  const pendingPassengerVehicles = new Map<number, any>()
+  let passengerVehicleFlushScheduled = false
+  const queuePassengerVehicleRefresh = (vehicle: any) => {
+    if (!vehicle) return
+    pendingPassengerVehicles.set(vehicle.id, vehicle)
+    if (passengerVehicleFlushScheduled) return
+    passengerVehicleFlushScheduled = true
+    queueMicrotask(() => {
+      passengerVehicleFlushScheduled = false
+      const vehicles = [...pendingPassengerVehicles.values()]
+      pendingPassengerVehicles.clear()
+      for (const pendingVehicle of vehicles) {
+        emitEntity(pendingVehicle)
+      }
+    })
+  }
+
   const eventListeners = {
     entitySpawn (e: any) {
       if (e.name === 'item_frame' || e.name === 'glow_item_frame') {
@@ -152,6 +169,12 @@ const connectAppWorldViewToBot = () => {
     },
     entityMoved (e: any) {
       emitEntity(e, 'entityMoved')
+    },
+    entityAttach (_passenger: any, vehicle: any) {
+      queuePassengerVehicleRefresh(vehicle)
+    },
+    entityDetach (_passenger: any, vehicle: any) {
+      queuePassengerVehicleRefresh(vehicle)
     },
     entityDead (e: any) {
       if (e === bot.entity) return

--- a/src/appViewer.ts
+++ b/src/appViewer.ts
@@ -122,6 +122,7 @@ const connectAppWorldViewToBot = () => {
     const renderHints = buildEntityRenderHints(e, {
       localVehicle: bot.vehicle,
       localBoatStatus: bot._boatPhysics?.getStatus?.() ?? null,
+      horseControllerActive: Boolean(bot._horsePhysics?.getCtx?.()),
       world: bot.world,
       waterIds: {
         waterId: bot.registry.blocksByName.water.id,

--- a/src/appViewer.ts
+++ b/src/appViewer.ts
@@ -122,12 +122,15 @@ const connectAppWorldViewToBot = () => {
     const renderHints = buildEntityRenderHints(e, {
       localVehicle: bot.vehicle,
       localBoatStatus: bot._boatPhysics?.getStatus?.() ?? null,
+      localBoatPaddleState: bot._boatPhysics?.getPaddleState?.() ?? null,
       horseControllerActive: Boolean(bot._horsePhysics?.getCtx?.()),
       world: bot.world,
       waterIds: {
         waterId: bot.registry.blocksByName.water.id,
         flowingWaterId: bot.registry.blocksByName.flowing_water?.id,
       },
+      version: bot.version,
+      entityMetadataKeys: bot.registry.entitiesByName[e.name]?.metadataKeys,
     })
     appViewer.worldView?.emit(name as any, {
       ...e,

--- a/src/appViewer.ts
+++ b/src/appViewer.ts
@@ -108,7 +108,7 @@ const connectAppWorldViewToBot = () => {
     }
   })
 
-  const emitEntity = (e, name = 'entity') => {
+  const emitEntity = (e, name = 'entity', eventMetadata = {}) => {
     if (!e) return
     if (e === bot.entity) {
       if (name === 'entity') {
@@ -134,6 +134,7 @@ const connectAppWorldViewToBot = () => {
     })
     appViewer.worldView?.emit(name as any, {
       ...e,
+      ...eventMetadata,
       pos: e.position,
       username: e.username,
       team: bot.teamMap[e.username] || bot.teamMap[e.uuid],
@@ -171,8 +172,8 @@ const connectAppWorldViewToBot = () => {
     entityEquip (e: any) {
       emitEntity(e)
     },
-    entityMoved (e: any) {
-      emitEntity(e, 'entityMoved')
+    entityMoved (e: any, eventMetadata: Record<string, unknown> = {}) {
+      emitEntity(e, 'entityMoved', eventMetadata)
     },
     entityAttach (_passenger: any, vehicle: any) {
       queuePassengerVehicleRefresh(vehicle)

--- a/src/appViewer.ts
+++ b/src/appViewer.ts
@@ -13,6 +13,7 @@ import { activeModalStack, miscUiState } from './globalState'
 import { options } from './optionsStorage'
 import { watchOptionsAfterWorldViewInit } from './watchOptions'
 import { updateLightRemeshBlockKey } from './mineflayer/updateLightRemeshKey'
+import { buildEntityRenderHints } from './boatRenderHints'
 
 // do not import this. Use global appViewer instead (without window prefix).
 export const appViewer = new AppViewer()
@@ -118,11 +119,21 @@ const connectAppWorldViewToBot = () => {
     if (!e.name) return // mineflayer received update for not spawned entity
     if (deadEntities.has(e.id)) return
     e.objectData = entitiesObjectData.get(e.id)
+    const renderHints = buildEntityRenderHints(e, {
+      localVehicle: bot.vehicle,
+      localBoatStatus: bot._boatPhysics?.getStatus?.() ?? null,
+      world: bot.world,
+      waterIds: {
+        waterId: bot.registry.blocksByName.water.id,
+        flowingWaterId: bot.registry.blocksByName.flowing_water?.id,
+      },
+    })
     appViewer.worldView?.emit(name as any, {
       ...e,
       pos: e.position,
       username: e.username,
       team: bot.teamMap[e.username] || bot.teamMap[e.uuid],
+      renderHints,
     })
   }
 

--- a/src/boatRenderHints.test.ts
+++ b/src/boatRenderHints.test.ts
@@ -293,6 +293,7 @@ test('local horse sets passengerLayout horse', () => {
   expect(hints.passengerLayout).toBe('horse')
   expect(hints.passengerIds).toEqual([1])
   expect(hints.localVehicleVerticalCameraLock).toBe('horse')
+  expect(hints.localVehicleYawLock).toBe('horse')
 })
 
 test('local horse without active controller omits vertical camera lock', () => {
@@ -312,6 +313,7 @@ test('local horse without active controller omits vertical camera lock', () => {
   })
   expect(hints.localVehicle).toBe(true)
   expect(hints.localVehicleVerticalCameraLock).toBeUndefined()
+  expect(hints.localVehicleYawLock).toBeUndefined()
 })
 
 test('remote horse omits localVehicle and vertical camera lock', () => {
@@ -330,6 +332,7 @@ test('remote horse omits localVehicle and vertical camera lock', () => {
   })
   expect(hints.localVehicle).toBeUndefined()
   expect(hints.localVehicleVerticalCameraLock).toBeUndefined()
+  expect(hints.localVehicleYawLock).toBeUndefined()
   expect(hints.passengerLayout).toBe('horse')
 })
 
@@ -349,6 +352,7 @@ test('local boat does not set horse vertical camera lock', () => {
     version: '1.17.1',
   })
   expect(hints.localVehicleVerticalCameraLock).toBeUndefined()
+  expect(hints.localVehicleYawLock).toBeUndefined()
 })
 
 test('local minecart does not set horse vertical camera lock', () => {
@@ -367,6 +371,7 @@ test('local minecart does not set horse vertical camera lock', () => {
     version: '1.17.1',
   })
   expect(hints.localVehicleVerticalCameraLock).toBeUndefined()
+  expect(hints.localVehicleYawLock).toBeUndefined()
 })
 
 test('empty horse passenger list still reports horse layout', () => {

--- a/src/boatRenderHints.test.ts
+++ b/src/boatRenderHints.test.ts
@@ -111,6 +111,7 @@ test('buildEntityRenderHints marks local vehicle and water patch', () => {
   const hints = buildEntityRenderHints(localBoat, {
     localVehicle: localBoat,
     localBoatStatus: BoatStatus.IN_WATER,
+    horseControllerActive: false,
     world: makeWorld({ '0,62,0': makeBlock(waterId, { level: 7 }) }),
     waterIds: { waterId, flowingWaterId },
   })
@@ -124,6 +125,7 @@ test('buildEntityRenderHints keeps remote boat on ordinary tween policy inputs',
   const hints = buildEntityRenderHints(remoteBoat, {
     localVehicle: { ...boatEntity, id: 1 },
     localBoatStatus: BoatStatus.IN_WATER,
+    horseControllerActive: false,
     world: makeWorld({ '0,62,0': makeBlock(waterId, { level: 7 }) }),
     waterIds: { waterId, flowingWaterId },
   })
@@ -137,6 +139,7 @@ test('buildEntityRenderHints sends an empty passenger list after boat detach', (
   const hints = buildEntityRenderHints(remoteBoat, {
     localVehicle: null,
     localBoatStatus: null,
+    horseControllerActive: false,
     world: makeWorld({}),
     waterIds: { waterId, flowingWaterId },
   })
@@ -156,6 +159,7 @@ test('local minecart receives localVehicle hint for camera-synced rendering', ()
   const hints = buildEntityRenderHints(localMinecart, {
     localVehicle: localMinecart,
     localBoatStatus: null,
+    horseControllerActive: false,
     world: makeWorld({}),
     waterIds: { waterId, flowingWaterId },
   })
@@ -182,6 +186,7 @@ test('remote minecart does not receive localVehicle hint', () => {
       passengers: [{ id: 7 }],
     },
     localBoatStatus: null,
+    horseControllerActive: false,
     world: makeWorld({}),
     waterIds: { waterId, flowingWaterId },
   })
@@ -201,6 +206,7 @@ test('minecart receives ordered passengerIds', () => {
   const hints = buildEntityRenderHints(minecart, {
     localVehicle: null,
     localBoatStatus: null,
+    horseControllerActive: false,
     world: makeWorld({}),
     waterIds: { waterId, flowingWaterId },
   })
@@ -219,6 +225,7 @@ test('minecart detach creates empty passenger list', () => {
   const hints = buildEntityRenderHints(minecart, {
     localVehicle: null,
     localBoatStatus: null,
+    horseControllerActive: false,
     world: makeWorld({}),
     waterIds: { waterId, flowingWaterId },
   })
@@ -240,6 +247,7 @@ test.each([
     {
       localVehicle: null,
       localBoatStatus: null,
+      horseControllerActive: false,
       world: makeWorld({}),
       waterIds: { waterId, flowingWaterId },
     },
@@ -267,15 +275,35 @@ test('local horse sets passengerLayout horse', () => {
   const hints = buildEntityRenderHints(horse, {
     localVehicle: horse,
     localBoatStatus: null,
+    horseControllerActive: true,
     world: makeWorld({}),
     waterIds: { waterId, flowingWaterId },
   })
   expect(hints.localVehicle).toBe(true)
   expect(hints.passengerLayout).toBe('horse')
   expect(hints.passengerIds).toEqual([1])
+  expect(hints.localVehicleVerticalCameraLock).toBe('horse')
 })
 
-test('remote horse omits localVehicle flag', () => {
+test('local horse without active controller omits vertical camera lock', () => {
+  const horse = {
+    name: 'horse',
+    id: 5,
+    position: new Vec3(0, 64, 0),
+    passengers: [{ id: 1 }],
+  }
+  const hints = buildEntityRenderHints(horse, {
+    localVehicle: horse,
+    localBoatStatus: null,
+    horseControllerActive: false,
+    world: makeWorld({}),
+    waterIds: { waterId, flowingWaterId },
+  })
+  expect(hints.localVehicle).toBe(true)
+  expect(hints.localVehicleVerticalCameraLock).toBeUndefined()
+})
+
+test('remote horse omits localVehicle and vertical camera lock', () => {
   const horse = {
     name: 'horse',
     position: new Vec3(0, 64, 0),
@@ -284,11 +312,47 @@ test('remote horse omits localVehicle flag', () => {
   const hints = buildEntityRenderHints(horse, {
     localVehicle: null,
     localBoatStatus: null,
+    horseControllerActive: false,
     world: makeWorld({}),
     waterIds: { waterId, flowingWaterId },
   })
   expect(hints.localVehicle).toBeUndefined()
+  expect(hints.localVehicleVerticalCameraLock).toBeUndefined()
   expect(hints.passengerLayout).toBe('horse')
+})
+
+test('local boat does not set horse vertical camera lock', () => {
+  const localBoat = {
+    ...boatEntity,
+    id: 1,
+    position: new Vec3(1, 63, 2),
+    passengers: [{ id: 7 }],
+  }
+  const hints = buildEntityRenderHints(localBoat, {
+    localVehicle: localBoat,
+    localBoatStatus: BoatStatus.IN_WATER,
+    horseControllerActive: true,
+    world: makeWorld({ '0,62,0': makeBlock(waterId, { level: 7 }) }),
+    waterIds: { waterId, flowingWaterId },
+  })
+  expect(hints.localVehicleVerticalCameraLock).toBeUndefined()
+})
+
+test('local minecart does not set horse vertical camera lock', () => {
+  const localMinecart = {
+    name: 'minecart',
+    id: 5,
+    position: new Vec3(1, 63, 2),
+    passengers: [{ id: 7 }],
+  }
+  const hints = buildEntityRenderHints(localMinecart, {
+    localVehicle: localMinecart,
+    localBoatStatus: null,
+    horseControllerActive: true,
+    world: makeWorld({}),
+    waterIds: { waterId, flowingWaterId },
+  })
+  expect(hints.localVehicleVerticalCameraLock).toBeUndefined()
 })
 
 test('empty horse passenger list still reports horse layout', () => {
@@ -300,6 +364,7 @@ test('empty horse passenger list still reports horse layout', () => {
   const hints = buildEntityRenderHints(horse, {
     localVehicle: null,
     localBoatStatus: null,
+    horseControllerActive: false,
     world: makeWorld({}),
     waterIds: { waterId, flowingWaterId },
   })

--- a/src/boatRenderHints.test.ts
+++ b/src/boatRenderHints.test.ts
@@ -5,6 +5,7 @@ import {
   buildEntityRenderHints,
   getLocalBoatWaterPatchVisible,
   getRemoteBoatWaterPatchVisible,
+  isRideableMinecartEntityName,
 } from './boatRenderHints'
 
 const waterId = 123
@@ -139,4 +140,83 @@ test('buildEntityRenderHints sends an empty passenger list after boat detach', (
     waterIds: { waterId, flowingWaterId },
   })
   expect(hints.boatPassengerIds).toEqual([])
+  expect(hints.passengerIds).toEqual([])
+})
+
+test('local minecart does not receive localVehicle hint', () => {
+  const localMinecart = {
+    name: 'minecart',
+    id: 5,
+    position: new Vec3(1, 63, 2),
+    width: 0.98,
+    height: 0.7,
+    passengers: [{ id: 7 }],
+  }
+  const hints = buildEntityRenderHints(localMinecart, {
+    localVehicle: localMinecart,
+    localBoatStatus: null,
+    world: makeWorld({}),
+    waterIds: { waterId, flowingWaterId },
+  })
+  expect(hints.localVehicle).toBeUndefined()
+  expect(hints.passengerLayout).toBe('minecart')
+  expect(hints.passengerIds).toEqual([7])
+})
+
+test('minecart receives ordered passengerIds', () => {
+  const minecart = {
+    name: 'chest_minecart',
+    id: 6,
+    position: new Vec3(0, 63, 0),
+    width: 0.98,
+    height: 0.7,
+    passengers: [{ id: 11 }, { id: 12 }],
+  }
+  const hints = buildEntityRenderHints(minecart, {
+    localVehicle: null,
+    localBoatStatus: null,
+    world: makeWorld({}),
+    waterIds: { waterId, flowingWaterId },
+  })
+  expect(hints.passengerIds).toEqual([11, 12])
+  expect(hints.passengerLayout).toBe('minecart')
+  expect(hints.boatPassengerIds).toBeUndefined()
+})
+
+test('minecart detach creates empty passenger list', () => {
+  const minecart = {
+    name: 'minecart',
+    id: 7,
+    position: new Vec3(0, 63, 0),
+    passengers: [],
+  }
+  const hints = buildEntityRenderHints(minecart, {
+    localVehicle: null,
+    localBoatStatus: null,
+    world: makeWorld({}),
+    waterIds: { waterId, flowingWaterId },
+  })
+  expect(hints.passengerIds).toEqual([])
+})
+
+test.each([
+  'minecart',
+  'chest_minecart',
+  'furnace_minecart',
+  'hopper_minecart',
+  'tnt_minecart',
+  'spawner_minecart',
+  'command_block_minecart',
+])('recognizes minecart variant %s', name => {
+  expect(isRideableMinecartEntityName(name)).toBe(true)
+  const hints = buildEntityRenderHints(
+    { name, position: new Vec3(0, 63, 0), passengers: [{ id: 1 }] },
+    {
+      localVehicle: null,
+      localBoatStatus: null,
+      world: makeWorld({}),
+      waterIds: { waterId, flowingWaterId },
+    },
+  )
+  expect(hints.passengerLayout).toBe('minecart')
 })

--- a/src/boatRenderHints.test.ts
+++ b/src/boatRenderHints.test.ts
@@ -1,0 +1,124 @@
+import { Vec3 } from 'vec3'
+import { expect, test } from 'vitest'
+import { BoatStatus } from '@nxg-org/mineflayer-physics-util'
+import {
+  buildEntityRenderHints,
+  getLocalBoatWaterPatchVisible,
+  getRemoteBoatWaterPatchVisible,
+} from './boatRenderHints'
+
+const waterId = 123
+const flowingWaterId = 124
+const stoneId = 1
+const airId = 0
+
+type StubBlock = {
+  type: number
+  name: string
+  getProperties: () => Record<string, unknown>
+}
+
+function makeBlock (type: number, props: Record<string, unknown> = {}): StubBlock {
+  return {
+    type,
+    name: type === waterId ? 'water' : type === flowingWaterId ? 'flowing_water' : type === stoneId ? 'stone' : 'air',
+    getProperties: () => props,
+  }
+}
+
+function makeWorld (blocks: Record<string, number | StubBlock | null>) {
+  return {
+    getBlock (pos: Vec3) {
+      const key = `${pos.x | 0},${pos.y | 0},${pos.z | 0}`
+      const entry = blocks[key]
+      if (entry === null) return null
+      if (typeof entry === 'object') return entry
+      if (entry == null) return makeBlock(airId)
+      return makeBlock(entry)
+    },
+  }
+}
+
+const boatEntity = {
+  name: 'oak_boat',
+  position: new Vec3(0, 62.2, 0),
+  width: 1.375,
+  height: 0.5625,
+}
+
+test('local boat patch visible only in IN_WATER status', () => {
+  expect(getLocalBoatWaterPatchVisible(BoatStatus.IN_WATER)).toBe(true)
+  expect(getLocalBoatWaterPatchVisible(BoatStatus.UNDER_WATER)).toBe(false)
+  expect(getLocalBoatWaterPatchVisible(BoatStatus.UNDER_FLOWING_WATER)).toBe(false)
+  expect(getLocalBoatWaterPatchVisible(BoatStatus.ON_LAND)).toBe(false)
+  expect(getLocalBoatWaterPatchVisible(BoatStatus.IN_AIR)).toBe(false)
+  expect(getLocalBoatWaterPatchVisible(null)).toBe(false)
+})
+
+test('remote boat patch visible on source water', () => {
+  const world = makeWorld({
+    '0,62,0': makeBlock(waterId, { level: 7 }),
+  })
+  expect(getRemoteBoatWaterPatchVisible(boatEntity, world, { waterId, flowingWaterId })).toBe(true)
+})
+
+test('remote boat patch hidden for fully submerged source water', () => {
+  const world = makeWorld({
+    '0,62,0': waterId,
+    '0,63,0': waterId,
+  })
+  expect(getRemoteBoatWaterPatchVisible(boatEntity, world, { waterId, flowingWaterId })).toBe(false)
+})
+
+test('remote boat patch hidden on flowing water cover', () => {
+  const world = makeWorld({
+    '0,62,0': waterId,
+    '0,63,0': makeBlock(flowingWaterId, { level: 3 }),
+  })
+  expect(getRemoteBoatWaterPatchVisible(boatEntity, world, { waterId, flowingWaterId })).toBe(false)
+})
+
+test('remote boat patch hidden on land', () => {
+  const world = makeWorld({
+    '0,62,0': stoneId,
+  })
+  expect(getRemoteBoatWaterPatchVisible(boatEntity, world, { waterId, flowingWaterId })).toBe(false)
+})
+
+test('remote boat patch hidden when world is unloaded', () => {
+  const world = makeWorld({
+    '0,62,0': null,
+  })
+  expect(getRemoteBoatWaterPatchVisible(boatEntity, world, { waterId, flowingWaterId })).toBe(false)
+})
+
+test('remote boat patch hidden for waterlogged full block at hull', () => {
+  const world = makeWorld({
+    '0,62,0': makeBlock(stoneId, { waterlogged: true }),
+  })
+  expect(getRemoteBoatWaterPatchVisible(boatEntity, world, { waterId, flowingWaterId })).toBe(false)
+})
+
+test('buildEntityRenderHints marks local vehicle and water patch', () => {
+  const localBoat = { ...boatEntity, id: 1, position: new Vec3(1, 63, 2) }
+  const hints = buildEntityRenderHints(localBoat, {
+    localVehicle: localBoat,
+    localBoatStatus: BoatStatus.IN_WATER,
+    world: makeWorld({ '0,62,0': makeBlock(waterId, { level: 7 }) }),
+    waterIds: { waterId, flowingWaterId },
+  })
+  expect(hints.localVehicle).toBe(true)
+  expect(hints.boatWaterPatchVisible).toBe(true)
+})
+
+test('buildEntityRenderHints keeps remote boat on ordinary tween policy inputs', () => {
+  const remoteBoat = { ...boatEntity, id: 2 }
+  const hints = buildEntityRenderHints(remoteBoat, {
+    localVehicle: { ...boatEntity, id: 1 },
+    localBoatStatus: BoatStatus.IN_WATER,
+    world: makeWorld({ '0,62,0': makeBlock(waterId, { level: 7 }) }),
+    waterIds: { waterId, flowingWaterId },
+  })
+  expect(hints.localVehicle).toBeUndefined()
+  expect(hints.boatWaterPatchVisible).toBe(true)
+})

--- a/src/boatRenderHints.test.ts
+++ b/src/boatRenderHints.test.ts
@@ -100,7 +100,12 @@ test('remote boat patch hidden for waterlogged full block at hull', () => {
 })
 
 test('buildEntityRenderHints marks local vehicle and water patch', () => {
-  const localBoat = { ...boatEntity, id: 1, position: new Vec3(1, 63, 2) }
+  const localBoat = {
+    ...boatEntity,
+    id: 1,
+    position: new Vec3(1, 63, 2),
+    passengers: [{ id: 7 }, { id: 8 }],
+  }
   const hints = buildEntityRenderHints(localBoat, {
     localVehicle: localBoat,
     localBoatStatus: BoatStatus.IN_WATER,
@@ -109,6 +114,7 @@ test('buildEntityRenderHints marks local vehicle and water patch', () => {
   })
   expect(hints.localVehicle).toBe(true)
   expect(hints.boatWaterPatchVisible).toBe(true)
+  expect(hints.boatPassengerIds).toEqual([7, 8])
 })
 
 test('buildEntityRenderHints keeps remote boat on ordinary tween policy inputs', () => {
@@ -121,4 +127,16 @@ test('buildEntityRenderHints keeps remote boat on ordinary tween policy inputs',
   })
   expect(hints.localVehicle).toBeUndefined()
   expect(hints.boatWaterPatchVisible).toBe(true)
+  expect(hints.boatPassengerIds).toEqual([])
+})
+
+test('buildEntityRenderHints sends an empty passenger list after boat detach', () => {
+  const remoteBoat = { ...boatEntity, id: 2, passengers: [] }
+  const hints = buildEntityRenderHints(remoteBoat, {
+    localVehicle: null,
+    localBoatStatus: null,
+    world: makeWorld({}),
+    waterIds: { waterId, flowingWaterId },
+  })
+  expect(hints.boatPassengerIds).toEqual([])
 })

--- a/src/boatRenderHints.test.ts
+++ b/src/boatRenderHints.test.ts
@@ -143,7 +143,7 @@ test('buildEntityRenderHints sends an empty passenger list after boat detach', (
   expect(hints.passengerIds).toEqual([])
 })
 
-test('local minecart does not receive localVehicle hint', () => {
+test('local minecart receives localVehicle hint for camera-synced rendering', () => {
   const localMinecart = {
     name: 'minecart',
     id: 5,
@@ -158,9 +158,34 @@ test('local minecart does not receive localVehicle hint', () => {
     world: makeWorld({}),
     waterIds: { waterId, flowingWaterId },
   })
-  expect(hints.localVehicle).toBeUndefined()
+  expect(hints.localVehicle).toBe(true)
   expect(hints.passengerLayout).toBe('minecart')
   expect(hints.passengerIds).toEqual([7])
+  expect(hints.boatWaterPatchVisible).toBeUndefined()
+})
+
+test('remote minecart does not receive localVehicle hint', () => {
+  const remoteMinecart = {
+    name: 'minecart',
+    id: 6,
+    position: new Vec3(0, 63, 0),
+    width: 0.98,
+    height: 0.7,
+    passengers: [{ id: 11 }],
+  }
+  const hints = buildEntityRenderHints(remoteMinecart, {
+    localVehicle: {
+      name: 'minecart',
+      id: 5,
+      position: new Vec3(1, 63, 2),
+      passengers: [{ id: 7 }],
+    },
+    localBoatStatus: null,
+    world: makeWorld({}),
+    waterIds: { waterId, flowingWaterId },
+  })
+  expect(hints.localVehicle).toBeUndefined()
+  expect(hints.passengerLayout).toBe('minecart')
 })
 
 test('minecart receives ordered passengerIds', () => {

--- a/src/boatRenderHints.test.ts
+++ b/src/boatRenderHints.test.ts
@@ -4,6 +4,7 @@ import { BoatStatus } from '@nxg-org/mineflayer-physics-util'
 import {
   buildEntityRenderHints,
   getLocalBoatWaterPatchVisible,
+  getRemoteBoatPaddleState,
   getRemoteBoatWaterPatchVisible,
   isRideableHorseEntityName,
   isRideableMinecartEntityName,
@@ -114,6 +115,7 @@ test('buildEntityRenderHints marks local vehicle and water patch', () => {
     horseControllerActive: false,
     world: makeWorld({ '0,62,0': makeBlock(waterId, { level: 7 }) }),
     waterIds: { waterId, flowingWaterId },
+    version: '1.17.1',
   })
   expect(hints.localVehicle).toBe(true)
   expect(hints.boatWaterPatchVisible).toBe(true)
@@ -128,6 +130,7 @@ test('buildEntityRenderHints keeps remote boat on ordinary tween policy inputs',
     horseControllerActive: false,
     world: makeWorld({ '0,62,0': makeBlock(waterId, { level: 7 }) }),
     waterIds: { waterId, flowingWaterId },
+    version: '1.17.1',
   })
   expect(hints.localVehicle).toBeUndefined()
   expect(hints.boatWaterPatchVisible).toBe(true)
@@ -142,6 +145,7 @@ test('buildEntityRenderHints sends an empty passenger list after boat detach', (
     horseControllerActive: false,
     world: makeWorld({}),
     waterIds: { waterId, flowingWaterId },
+    version: '1.17.1',
   })
   expect(hints.boatPassengerIds).toEqual([])
   expect(hints.passengerIds).toEqual([])
@@ -162,6 +166,7 @@ test('local minecart receives localVehicle hint for camera-synced rendering', ()
     horseControllerActive: false,
     world: makeWorld({}),
     waterIds: { waterId, flowingWaterId },
+    version: '1.17.1',
   })
   expect(hints.localVehicle).toBe(true)
   expect(hints.passengerLayout).toBe('minecart')
@@ -189,6 +194,7 @@ test('remote minecart does not receive localVehicle hint', () => {
     horseControllerActive: false,
     world: makeWorld({}),
     waterIds: { waterId, flowingWaterId },
+    version: '1.17.1',
   })
   expect(hints.localVehicle).toBeUndefined()
   expect(hints.passengerLayout).toBe('minecart')
@@ -209,6 +215,7 @@ test('minecart receives ordered passengerIds', () => {
     horseControllerActive: false,
     world: makeWorld({}),
     waterIds: { waterId, flowingWaterId },
+    version: '1.17.1',
   })
   expect(hints.passengerIds).toEqual([11, 12])
   expect(hints.passengerLayout).toBe('minecart')
@@ -228,6 +235,7 @@ test('minecart detach creates empty passenger list', () => {
     horseControllerActive: false,
     world: makeWorld({}),
     waterIds: { waterId, flowingWaterId },
+    version: '1.17.1',
   })
   expect(hints.passengerIds).toEqual([])
 })
@@ -250,6 +258,7 @@ test.each([
       horseControllerActive: false,
       world: makeWorld({}),
       waterIds: { waterId, flowingWaterId },
+      version: '1.17.1',
     },
   )
   expect(hints.passengerLayout).toBe('minecart')
@@ -278,6 +287,7 @@ test('local horse sets passengerLayout horse', () => {
     horseControllerActive: true,
     world: makeWorld({}),
     waterIds: { waterId, flowingWaterId },
+    version: '1.17.1',
   })
   expect(hints.localVehicle).toBe(true)
   expect(hints.passengerLayout).toBe('horse')
@@ -298,6 +308,7 @@ test('local horse without active controller omits vertical camera lock', () => {
     horseControllerActive: false,
     world: makeWorld({}),
     waterIds: { waterId, flowingWaterId },
+    version: '1.17.1',
   })
   expect(hints.localVehicle).toBe(true)
   expect(hints.localVehicleVerticalCameraLock).toBeUndefined()
@@ -315,6 +326,7 @@ test('remote horse omits localVehicle and vertical camera lock', () => {
     horseControllerActive: false,
     world: makeWorld({}),
     waterIds: { waterId, flowingWaterId },
+    version: '1.17.1',
   })
   expect(hints.localVehicle).toBeUndefined()
   expect(hints.localVehicleVerticalCameraLock).toBeUndefined()
@@ -334,6 +346,7 @@ test('local boat does not set horse vertical camera lock', () => {
     horseControllerActive: true,
     world: makeWorld({ '0,62,0': makeBlock(waterId, { level: 7 }) }),
     waterIds: { waterId, flowingWaterId },
+    version: '1.17.1',
   })
   expect(hints.localVehicleVerticalCameraLock).toBeUndefined()
 })
@@ -351,6 +364,7 @@ test('local minecart does not set horse vertical camera lock', () => {
     horseControllerActive: true,
     world: makeWorld({}),
     waterIds: { waterId, flowingWaterId },
+    version: '1.17.1',
   })
   expect(hints.localVehicleVerticalCameraLock).toBeUndefined()
 })
@@ -367,7 +381,152 @@ test('empty horse passenger list still reports horse layout', () => {
     horseControllerActive: false,
     world: makeWorld({}),
     waterIds: { waterId, flowingWaterId },
+    version: '1.17.1',
   })
   expect(hints.passengerIds).toEqual([])
   expect(hints.passengerLayout).toBe('horse')
+})
+
+test('local boat paddle hints pass through physics state unchanged', () => {
+  const localBoat = {
+    ...boatEntity,
+    id: 1,
+    passengers: [{ id: 7 }],
+  }
+  const hints = buildEntityRenderHints(localBoat, {
+    localVehicle: localBoat,
+    localBoatStatus: BoatStatus.IN_WATER,
+    localBoatPaddleState: { leftPaddle: true, rightPaddle: false },
+    horseControllerActive: false,
+    world: makeWorld({}),
+    waterIds: { waterId, flowingWaterId },
+    version: '1.17.1',
+  })
+  expect(hints.boatPaddleLeft).toBe(true)
+  expect(hints.boatPaddleRight).toBe(false)
+})
+
+test('local boat paddle hints default to false when physics state is null', () => {
+  const localBoat = {
+    ...boatEntity,
+    id: 1,
+    passengers: [{ id: 7 }],
+  }
+  const hints = buildEntityRenderHints(localBoat, {
+    localVehicle: localBoat,
+    localBoatStatus: null,
+    localBoatPaddleState: null,
+    horseControllerActive: false,
+    world: makeWorld({}),
+    waterIds: { waterId, flowingWaterId },
+    version: '1.17.1',
+  })
+  expect(hints.boatPaddleLeft).toBe(false)
+  expect(hints.boatPaddleRight).toBe(false)
+})
+
+test('remote boat paddle hints resolve 1.17.1 metadata indices 12 and 13', () => {
+  const remoteBoat = {
+    ...boatEntity,
+    id: 2,
+    passengers: [{ id: 9 }],
+    metadata: [false, false, false, false, false, false, false, false, false, false, false, false, true, false],
+  }
+  const hints = buildEntityRenderHints(remoteBoat, {
+    localVehicle: null,
+    localBoatStatus: null,
+    horseControllerActive: false,
+    world: makeWorld({}),
+    waterIds: { waterId, flowingWaterId },
+    version: '1.17.1',
+  })
+  expect(hints.boatPaddleLeft).toBe(true)
+  expect(hints.boatPaddleRight).toBe(false)
+})
+
+test('remote boat paddle hints prefer named metadata keys when supplied', () => {
+  const remoteBoat = {
+    ...boatEntity,
+    id: 2,
+    passengers: [{ id: 9 }],
+    metadata: [false, false, true, false],
+  }
+  const hints = buildEntityRenderHints(remoteBoat, {
+    localVehicle: null,
+    localBoatStatus: null,
+    horseControllerActive: false,
+    world: makeWorld({}),
+    waterIds: { waterId, flowingWaterId },
+    version: '1.19.4',
+    entityMetadataKeys: ['shared_flags', 'air_supply', 'paddle_left', 'paddle_right'],
+  })
+  expect(hints.boatPaddleLeft).toBe(true)
+  expect(hints.boatPaddleRight).toBe(false)
+})
+
+test('remote boat without passengers forces paddle hints false', () => {
+  const remoteBoat = {
+    ...boatEntity,
+    id: 2,
+    passengers: [],
+    metadata: [false, false, false, false, false, false, false, false, false, false, false, false, true, true],
+  }
+  const hints = buildEntityRenderHints(remoteBoat, {
+    localVehicle: null,
+    localBoatStatus: null,
+    horseControllerActive: false,
+    world: makeWorld({}),
+    waterIds: { waterId, flowingWaterId },
+    version: '1.17.1',
+  })
+  expect(hints.boatPaddleLeft).toBe(false)
+  expect(hints.boatPaddleRight).toBe(false)
+})
+
+test('remote boat never receives local physics paddle state', () => {
+  const remoteBoat = {
+    ...boatEntity,
+    id: 2,
+    passengers: [{ id: 9 }],
+    metadata: [false, false, false, false, false, false, false, false, false, false, false, false, false, false],
+  }
+  const hints = buildEntityRenderHints(remoteBoat, {
+    localVehicle: { ...boatEntity, id: 1 },
+    localBoatStatus: BoatStatus.IN_WATER,
+    localBoatPaddleState: { leftPaddle: true, rightPaddle: true },
+    horseControllerActive: false,
+    world: makeWorld({}),
+    waterIds: { waterId, flowingWaterId },
+    version: '1.17.1',
+  })
+  expect(hints.boatPaddleLeft).toBe(false)
+  expect(hints.boatPaddleRight).toBe(false)
+})
+
+test('getRemoteBoatPaddleState resolves all four boolean combinations on 1.17.1', () => {
+  const entity = {
+    ...boatEntity,
+    passengers: [{ id: 1 }],
+    metadata: [false, false, false, false, false, false, false, false, false, false, false, false, false, false],
+  }
+  expect(getRemoteBoatPaddleState(entity, '1.17.1').leftPaddle).toBe(false)
+  expect(getRemoteBoatPaddleState(entity, '1.17.1').rightPaddle).toBe(false)
+
+  entity.metadata[12] = true
+  expect(getRemoteBoatPaddleState(entity, '1.17.1')).toEqual({ leftPaddle: true, rightPaddle: false })
+
+  entity.metadata[13] = true
+  expect(getRemoteBoatPaddleState(entity, '1.17.1')).toEqual({ leftPaddle: true, rightPaddle: true })
+
+  entity.metadata[12] = false
+  expect(getRemoteBoatPaddleState(entity, '1.17.1')).toEqual({ leftPaddle: false, rightPaddle: true })
+})
+
+test('getRemoteBoatPaddleState ignores truthy non-boolean metadata', () => {
+  const entity = {
+    ...boatEntity,
+    passengers: [{ id: 1 }],
+    metadata: [false, false, false, false, false, false, false, false, false, false, false, false, 1, 'true'],
+  }
+  expect(getRemoteBoatPaddleState(entity, '1.17.1')).toEqual({ leftPaddle: false, rightPaddle: false })
 })

--- a/src/boatRenderHints.test.ts
+++ b/src/boatRenderHints.test.ts
@@ -5,6 +5,7 @@ import {
   buildEntityRenderHints,
   getLocalBoatWaterPatchVisible,
   getRemoteBoatWaterPatchVisible,
+  isRideableHorseEntityName,
   isRideableMinecartEntityName,
 } from './boatRenderHints'
 
@@ -16,10 +17,10 @@ const airId = 0
 type StubBlock = {
   type: number
   name: string
-  getProperties: () => Record<string, unknown>
+  getProperties: () => Record<string, string | number | boolean>
 }
 
-function makeBlock (type: number, props: Record<string, unknown> = {}): StubBlock {
+function makeBlock (type: number, props: Record<string, string | number | boolean> = {}): StubBlock {
   return {
     type,
     name: type === waterId ? 'water' : type === flowingWaterId ? 'flowing_water' : type === stoneId ? 'stone' : 'air',
@@ -30,11 +31,11 @@ function makeBlock (type: number, props: Record<string, unknown> = {}): StubBloc
 function makeWorld (blocks: Record<string, number | StubBlock | null>) {
   return {
     getBlock (pos: Vec3) {
-      const key = `${pos.x | 0},${pos.y | 0},${pos.z | 0}`
+      const key = `${Math.trunc(pos.x)},${Math.trunc(pos.y)},${Math.trunc(pos.z)}`
       const entry = blocks[key]
       if (entry === null) return null
       if (typeof entry === 'object') return entry
-      if (entry == null) return makeBlock(airId)
+      if (entry === undefined) return makeBlock(airId)
       return makeBlock(entry)
     },
   }
@@ -244,4 +245,64 @@ test.each([
     },
   )
   expect(hints.passengerLayout).toBe('minecart')
+})
+
+test.each([
+  'horse',
+  'donkey',
+  'mule',
+  'skeleton_horse',
+  'zombie_horse',
+])('recognizes horse variant %s', name => {
+  expect(isRideableHorseEntityName(name)).toBe(true)
+})
+
+test('local horse sets passengerLayout horse', () => {
+  const horse = {
+    name: 'horse',
+    id: 5,
+    position: new Vec3(0, 64, 0),
+    passengers: [{ id: 1 }],
+  }
+  const hints = buildEntityRenderHints(horse, {
+    localVehicle: horse,
+    localBoatStatus: null,
+    world: makeWorld({}),
+    waterIds: { waterId, flowingWaterId },
+  })
+  expect(hints.localVehicle).toBe(true)
+  expect(hints.passengerLayout).toBe('horse')
+  expect(hints.passengerIds).toEqual([1])
+})
+
+test('remote horse omits localVehicle flag', () => {
+  const horse = {
+    name: 'horse',
+    position: new Vec3(0, 64, 0),
+    passengers: [{ id: 2 }],
+  }
+  const hints = buildEntityRenderHints(horse, {
+    localVehicle: null,
+    localBoatStatus: null,
+    world: makeWorld({}),
+    waterIds: { waterId, flowingWaterId },
+  })
+  expect(hints.localVehicle).toBeUndefined()
+  expect(hints.passengerLayout).toBe('horse')
+})
+
+test('empty horse passenger list still reports horse layout', () => {
+  const horse = {
+    name: 'horse',
+    position: new Vec3(0, 64, 0),
+    passengers: [],
+  }
+  const hints = buildEntityRenderHints(horse, {
+    localVehicle: null,
+    localBoatStatus: null,
+    world: makeWorld({}),
+    waterIds: { waterId, flowingWaterId },
+  })
+  expect(hints.passengerIds).toEqual([])
+  expect(hints.passengerLayout).toBe('horse')
 })

--- a/src/boatRenderHints.ts
+++ b/src/boatRenderHints.ts
@@ -29,8 +29,15 @@ export type VehicleRenderHints = {
   passengerIds?: number[]
   passengerLayout?: 'boat' | 'minecart' | 'horse'
   boatWaterPatchVisible?: boolean
+  boatPaddleLeft?: boolean
+  boatPaddleRight?: boolean
   /** @deprecated Use passengerIds */
   boatPassengerIds?: number[]
+}
+
+export type BoatPaddleState = {
+  leftPaddle: boolean
+  rightPaddle: boolean
 }
 
 const RIDEABLE_MINECART_ENTITY_NAMES = new Set([
@@ -183,14 +190,79 @@ export function getLocalBoatWaterPatchVisible (status: BoatStatus | null | undef
   return status === BoatStatus.IN_WATER
 }
 
+type EntityWithMetadata = VehicleEntityLike & {
+  metadata?: unknown[]
+}
+
+export function getRemoteBoatPaddleState (
+  entity: EntityWithMetadata,
+  version: string,
+  metadataKeys?: string[],
+): BoatPaddleState {
+  const passengerIds = collectPassengerIds(entity)
+  if (passengerIds.length === 0) {
+    return { leftPaddle: false, rightPaddle: false }
+  }
+
+  let leftIndex = -1
+  let rightIndex = -1
+
+  if (metadataKeys?.includes('paddle_left') && metadataKeys?.includes('paddle_right')) {
+    leftIndex = metadataKeys.indexOf('paddle_left')
+    rightIndex = metadataKeys.indexOf('paddle_right')
+  } else if (version === '1.17' || version === '1.17.1') {
+    leftIndex = 12
+    rightIndex = 13
+  } else {
+    return { leftPaddle: false, rightPaddle: false }
+  }
+
+  const metadata = entity.metadata
+  if (!Array.isArray(metadata)) {
+    return { leftPaddle: false, rightPaddle: false }
+  }
+
+  return {
+    leftPaddle: metadata[leftIndex] === true,
+    rightPaddle: metadata[rightIndex] === true,
+  }
+}
+
+function resolveBoatPaddleHints (
+  entity: EntityWithMetadata,
+  isLocalVehicle: boolean,
+  options: {
+    localBoatPaddleState?: BoatPaddleState | null
+    version: string
+    entityMetadataKeys?: string[]
+  },
+): Pick<VehicleRenderHints, 'boatPaddleLeft' | 'boatPaddleRight'> {
+  if (isLocalVehicle) {
+    const state = options.localBoatPaddleState
+    return {
+      boatPaddleLeft: state?.leftPaddle === true,
+      boatPaddleRight: state?.rightPaddle === true,
+    }
+  }
+
+  const remote = getRemoteBoatPaddleState(entity, options.version, options.entityMetadataKeys)
+  return {
+    boatPaddleLeft: remote.leftPaddle,
+    boatPaddleRight: remote.rightPaddle,
+  }
+}
+
 export function buildEntityRenderHints (
   entity: VehicleEntityLike,
   options: {
     localVehicle: VehicleEntityLike | null | undefined
     localBoatStatus: BoatStatus | null | undefined
+    localBoatPaddleState?: BoatPaddleState | null
     horseControllerActive: boolean
     world: WorldLike
     waterIds: WaterIds
+    version: string
+    entityMetadataKeys?: string[]
   },
 ): VehicleRenderHints {
   const renderHints: VehicleRenderHints = {}
@@ -209,6 +281,7 @@ export function buildEntityRenderHints (
     renderHints.passengerIds = passengerIds
     renderHints.boatPassengerIds = passengerIds
     renderHints.passengerLayout = 'boat'
+    Object.assign(renderHints, resolveBoatPaddleHints(entity, renderHints.localVehicle === true, options))
     if (renderHints.localVehicle) {
       renderHints.boatWaterPatchVisible = getLocalBoatWaterPatchVisible(options.localBoatStatus)
     } else {

--- a/src/boatRenderHints.ts
+++ b/src/boatRenderHints.ts
@@ -3,7 +3,7 @@ import type { Block } from 'prismarine-block'
 import { isBoatEntityName } from 'minecraft-renderer/src/three/entity/boatModelRotation'
 import { BoatStatus } from '@nxg-org/mineflayer-physics-util'
 
-type BoatEntityLike = {
+type VehicleEntityLike = {
   name?: string
   position: Vec3
   width?: number
@@ -20,7 +20,37 @@ type WaterIds = {
   flowingWaterId?: number
 }
 
-function getEntityBB (entity: BoatEntityLike) {
+export type VehicleRenderHints = {
+  localVehicle?: boolean
+  passengerIds?: number[]
+  passengerLayout?: 'boat' | 'minecart'
+  boatWaterPatchVisible?: boolean
+  /** @deprecated Use passengerIds */
+  boatPassengerIds?: number[]
+}
+
+const RIDEABLE_MINECART_ENTITY_NAMES = new Set([
+  'minecart',
+  'chest_minecart',
+  'furnace_minecart',
+  'hopper_minecart',
+  'tnt_minecart',
+  'spawner_minecart',
+  'command_block_minecart',
+])
+
+export function isRideableMinecartEntityName (name?: string): boolean {
+  if (!name) return false
+  return RIDEABLE_MINECART_ENTITY_NAMES.has(name)
+}
+
+function collectPassengerIds (entity: VehicleEntityLike): number[] {
+  return (entity.passengers ?? [])
+    .map(passenger => passenger.id)
+    .filter((id): id is number => typeof id === 'number' && Number.isInteger(id))
+}
+
+function getEntityBB (entity: VehicleEntityLike) {
   const width = entity.width ?? 1.375
   const height = entity.height ?? 0.5625
   const halfWidth = width / 2
@@ -118,7 +148,7 @@ function isInWater (bb: ReturnType<typeof getEntityBB>, world: WorldLike, ids: W
 }
 
 export function getRemoteBoatWaterPatchVisible (
-  entity: BoatEntityLike,
+  entity: VehicleEntityLike,
   world: WorldLike,
   ids: WaterIds,
 ): boolean {
@@ -137,32 +167,38 @@ export function getLocalBoatWaterPatchVisible (status: BoatStatus | null | undef
 }
 
 export function buildEntityRenderHints (
-  entity: BoatEntityLike & { id?: number },
+  entity: VehicleEntityLike & { id?: number },
   options: {
-    localVehicle: BoatEntityLike | null | undefined
+    localVehicle: VehicleEntityLike | null | undefined
     localBoatStatus: BoatStatus | null | undefined
     world: WorldLike
     waterIds: WaterIds
   },
-) {
-  const renderHints: {
-    localVehicle?: boolean
-    boatWaterPatchVisible?: boolean
-    boatPassengerIds?: number[]
-  } = {}
-  if (options.localVehicle && entity === options.localVehicle) {
+): VehicleRenderHints {
+  const renderHints: VehicleRenderHints = {}
+  const isLocalControlledBoat = options.localVehicle === entity && isBoatEntityName(entity.name)
+  if (isLocalControlledBoat) {
     renderHints.localVehicle = true
   }
-  if (!isBoatEntityName(entity.name)) {
+
+  const passengerIds = collectPassengerIds(entity)
+
+  if (isBoatEntityName(entity.name)) {
+    renderHints.passengerIds = passengerIds
+    renderHints.boatPassengerIds = passengerIds
+    renderHints.passengerLayout = 'boat'
+    if (renderHints.localVehicle) {
+      renderHints.boatWaterPatchVisible = getLocalBoatWaterPatchVisible(options.localBoatStatus)
+    } else {
+      renderHints.boatWaterPatchVisible = getRemoteBoatWaterPatchVisible(entity, options.world, options.waterIds)
+    }
     return renderHints
   }
-  renderHints.boatPassengerIds = (entity.passengers ?? [])
-    .map(passenger => passenger.id)
-    .filter((id): id is number => typeof id === 'number' && Number.isInteger(id))
-  if (renderHints.localVehicle) {
-    renderHints.boatWaterPatchVisible = getLocalBoatWaterPatchVisible(options.localBoatStatus)
-  } else {
-    renderHints.boatWaterPatchVisible = getRemoteBoatWaterPatchVisible(entity, options.world, options.waterIds)
+
+  if (isRideableMinecartEntityName(entity.name)) {
+    renderHints.passengerIds = passengerIds
+    renderHints.passengerLayout = 'minecart'
   }
+
   return renderHints
 }

--- a/src/boatRenderHints.ts
+++ b/src/boatRenderHints.ts
@@ -8,6 +8,7 @@ type BoatEntityLike = {
   position: Vec3
   width?: number
   height?: number
+  passengers?: Array<{ id?: number }>
 }
 
 type WorldLike = {
@@ -147,6 +148,7 @@ export function buildEntityRenderHints (
   const renderHints: {
     localVehicle?: boolean
     boatWaterPatchVisible?: boolean
+    boatPassengerIds?: number[]
   } = {}
   if (options.localVehicle && entity === options.localVehicle) {
     renderHints.localVehicle = true
@@ -154,6 +156,9 @@ export function buildEntityRenderHints (
   if (!isBoatEntityName(entity.name)) {
     return renderHints
   }
+  renderHints.boatPassengerIds = (entity.passengers ?? [])
+    .map(passenger => passenger.id)
+    .filter((id): id is number => typeof id === 'number' && Number.isInteger(id))
   if (renderHints.localVehicle) {
     renderHints.boatWaterPatchVisible = getLocalBoatWaterPatchVisible(options.localBoatStatus)
   } else {

--- a/src/boatRenderHints.ts
+++ b/src/boatRenderHints.ts
@@ -4,6 +4,7 @@ import { isBoatEntityName } from 'minecraft-renderer/src/three/entity/boatModelR
 import { BoatStatus } from '@nxg-org/mineflayer-physics-util'
 
 type VehicleEntityLike = {
+  id?: number
   name?: string
   position: Vec3
   width?: number
@@ -11,8 +12,10 @@ type VehicleEntityLike = {
   passengers?: Array<{ id?: number }>
 }
 
+type BlockLike = Pick<Block, 'type' | 'getProperties'>
+
 type WorldLike = {
-  getBlock: (pos: Vec3) => Block | null
+  getBlock: (pos: Vec3) => BlockLike | null
 }
 
 type WaterIds = {
@@ -23,7 +26,7 @@ type WaterIds = {
 export type VehicleRenderHints = {
   localVehicle?: boolean
   passengerIds?: number[]
-  passengerLayout?: 'boat' | 'minecart'
+  passengerLayout?: 'boat' | 'minecart' | 'horse'
   boatWaterPatchVisible?: boolean
   /** @deprecated Use passengerIds */
   boatPassengerIds?: number[]
@@ -38,6 +41,19 @@ const RIDEABLE_MINECART_ENTITY_NAMES = new Set([
   'spawner_minecart',
   'command_block_minecart',
 ])
+
+const RIDEABLE_HORSE_ENTITY_NAMES = new Set([
+  'horse',
+  'donkey',
+  'mule',
+  'skeleton_horse',
+  'zombie_horse',
+])
+
+export function isRideableHorseEntityName (name?: string): boolean {
+  if (!name) return false
+  return RIDEABLE_HORSE_ENTITY_NAMES.has(name)
+}
 
 export function isRideableMinecartEntityName (name?: string): boolean {
   if (!name) return false
@@ -65,20 +81,20 @@ function getEntityBB (entity: VehicleEntityLike) {
   }
 }
 
-function isWaterBlock (block: Block | null | undefined, ids: WaterIds): block is Block {
+function isWaterBlock (block: BlockLike | null | undefined, ids: WaterIds): block is BlockLike {
   if (!block) return false
   if (block.type === ids.waterId) return true
-  if (ids.flowingWaterId != null && block.type === ids.flowingWaterId) return true
+  if (ids.flowingWaterId !== null && ids.flowingWaterId !== undefined && block.type === ids.flowingWaterId) return true
   return !!block.getProperties?.().waterlogged
 }
 
-function isSourceWater (block: Block, ids: WaterIds): boolean {
+function isSourceWater (block: BlockLike, ids: WaterIds): boolean {
   if (block.getProperties?.().waterlogged) return true
   if (block.type !== ids.waterId) return false
   return Number(block.getProperties?.().level ?? 0) === 0
 }
 
-function getFluidHeight (block: Block, world: WorldLike, pos: Vec3, ids: WaterIds): number {
+function getFluidHeight (block: BlockLike, world: WorldLike, pos: Vec3, ids: WaterIds): number {
   const above = world.getBlock(pos.offset(0, 1, 0))
   if (above && isWaterBlock(above, ids) && (above.type === block.type || above.getProperties?.().waterlogged)) {
     return 1
@@ -105,7 +121,7 @@ function isUnderwater (bb: ReturnType<typeof getEntityBB>, world: WorldLike, ids
     for (cursor.x = minX; cursor.x < maxX; cursor.x++) {
       for (cursor.z = minZ; cursor.z < maxZ; cursor.z++) {
         const block = world.getBlock(cursor)
-        if (block == null) return null
+        if (block === null) return null
         if (!isWaterBlock(block, ids)) continue
         const fluidHeight = cursor.y + getFluidHeight(block, world, cursor, ids)
         if (topY < fluidHeight) {
@@ -118,7 +134,7 @@ function isUnderwater (bb: ReturnType<typeof getEntityBB>, world: WorldLike, ids
     }
   }
 
-  return foundSource ? true : false
+  return foundSource
 }
 
 function isInWater (bb: ReturnType<typeof getEntityBB>, world: WorldLike, ids: WaterIds): boolean | null {
@@ -134,7 +150,7 @@ function isInWater (bb: ReturnType<typeof getEntityBB>, world: WorldLike, ids: W
     for (cursor.y = minY; cursor.y < maxY; cursor.y++) {
       for (cursor.z = minZ; cursor.z < maxZ; cursor.z++) {
         const block = world.getBlock(cursor)
-        if (block == null) return null
+        if (block === null) return null
         if (!isWaterBlock(block, ids)) continue
         const fluidHeight = cursor.y + getFluidHeight(block, world, cursor, ids)
         if (bb.minY < fluidHeight) {
@@ -155,10 +171,10 @@ export function getRemoteBoatWaterPatchVisible (
   if (!isBoatEntityName(entity.name)) return false
   const bb = getEntityBB(entity)
   const underwater = isUnderwater(bb, world, ids)
-  if (underwater == null) return false
+  if (underwater === null) return false
   if (underwater) return false
   const inWater = isInWater(bb, world, ids)
-  if (inWater == null) return false
+  if (inWater === null) return false
   return inWater
 }
 
@@ -167,7 +183,7 @@ export function getLocalBoatWaterPatchVisible (status: BoatStatus | null | undef
 }
 
 export function buildEntityRenderHints (
-  entity: VehicleEntityLike & { id?: number },
+  entity: VehicleEntityLike,
   options: {
     localVehicle: VehicleEntityLike | null | undefined
     localBoatStatus: BoatStatus | null | undefined
@@ -177,7 +193,9 @@ export function buildEntityRenderHints (
 ): VehicleRenderHints {
   const renderHints: VehicleRenderHints = {}
   const isLocalVehicle = options.localVehicle === entity && (
-    isBoatEntityName(entity.name) || isRideableMinecartEntityName(entity.name)
+    isBoatEntityName(entity.name) ||
+    isRideableMinecartEntityName(entity.name) ||
+    isRideableHorseEntityName(entity.name)
   )
   if (isLocalVehicle) {
     renderHints.localVehicle = true
@@ -200,6 +218,11 @@ export function buildEntityRenderHints (
   if (isRideableMinecartEntityName(entity.name)) {
     renderHints.passengerIds = passengerIds
     renderHints.passengerLayout = 'minecart'
+  }
+
+  if (isRideableHorseEntityName(entity.name)) {
+    renderHints.passengerIds = passengerIds
+    renderHints.passengerLayout = 'horse'
   }
 
   return renderHints

--- a/src/boatRenderHints.ts
+++ b/src/boatRenderHints.ts
@@ -1,0 +1,163 @@
+import { Vec3 } from 'vec3'
+import type { Block } from 'prismarine-block'
+import { isBoatEntityName } from 'minecraft-renderer/src/three/entity/boatModelRotation'
+import { BoatStatus } from '@nxg-org/mineflayer-physics-util'
+
+type BoatEntityLike = {
+  name?: string
+  position: Vec3
+  width?: number
+  height?: number
+}
+
+type WorldLike = {
+  getBlock: (pos: Vec3) => Block | null
+}
+
+type WaterIds = {
+  waterId: number
+  flowingWaterId?: number
+}
+
+function getEntityBB (entity: BoatEntityLike) {
+  const width = entity.width ?? 1.375
+  const height = entity.height ?? 0.5625
+  const halfWidth = width / 2
+  const { x, y, z } = entity.position
+  return {
+    minX: x - halfWidth,
+    maxX: x + halfWidth,
+    minY: y,
+    maxY: y + height,
+    minZ: z - halfWidth,
+    maxZ: z + halfWidth,
+  }
+}
+
+function isWaterBlock (block: Block | null | undefined, ids: WaterIds): block is Block {
+  if (!block) return false
+  if (block.type === ids.waterId) return true
+  if (ids.flowingWaterId != null && block.type === ids.flowingWaterId) return true
+  return !!block.getProperties?.().waterlogged
+}
+
+function isSourceWater (block: Block, ids: WaterIds): boolean {
+  if (block.getProperties?.().waterlogged) return true
+  if (block.type !== ids.waterId) return true
+  return Number(block.getProperties?.().level ?? 0) === 0
+}
+
+function getFluidHeight (block: Block, world: WorldLike, pos: Vec3, ids: WaterIds): number {
+  const above = world.getBlock(pos.offset(0, 1, 0))
+  if (above && isWaterBlock(above, ids) && (above.type === block.type || above.getProperties?.().waterlogged)) {
+    return 1
+  }
+  if (isWaterBlock(block, ids)) {
+    const level = Number(block.getProperties?.().level ?? 0)
+    return 1 - level / 9
+  }
+  return 0
+}
+
+function isUnderwater (bb: ReturnType<typeof getEntityBB>, world: WorldLike, ids: WaterIds): boolean | null {
+  const topY = bb.maxY + 0.001
+  const minX = Math.floor(bb.minX)
+  const maxX = Math.ceil(bb.maxX)
+  const minY = Math.floor(bb.maxY)
+  const maxY = Math.ceil(topY)
+  const minZ = Math.floor(bb.minZ)
+  const maxZ = Math.ceil(bb.maxZ)
+  let foundSource = false
+  const cursor = new Vec3(0, 0, 0)
+
+  for (cursor.y = minY; cursor.y < maxY; cursor.y++) {
+    for (cursor.x = minX; cursor.x < maxX; cursor.x++) {
+      for (cursor.z = minZ; cursor.z < maxZ; cursor.z++) {
+        const block = world.getBlock(cursor)
+        if (block == null) return null
+        if (!isWaterBlock(block, ids)) continue
+        const fluidHeight = cursor.y + getFluidHeight(block, world, cursor, ids)
+        if (topY < fluidHeight) {
+          if (!isSourceWater(block, ids)) {
+            return true
+          }
+          foundSource = true
+        }
+      }
+    }
+  }
+
+  return foundSource ? true : false
+}
+
+function isInWater (bb: ReturnType<typeof getEntityBB>, world: WorldLike, ids: WaterIds): boolean | null {
+  const minX = Math.floor(bb.minX)
+  const maxX = Math.ceil(bb.maxX)
+  const minY = Math.floor(bb.minY)
+  const maxY = Math.ceil(bb.minY + 0.001)
+  const minZ = Math.floor(bb.minZ)
+  const maxZ = Math.ceil(bb.maxZ)
+  const cursor = new Vec3(0, 0, 0)
+
+  for (cursor.x = minX; cursor.x < maxX; cursor.x++) {
+    for (cursor.y = minY; cursor.y < maxY; cursor.y++) {
+      for (cursor.z = minZ; cursor.z < maxZ; cursor.z++) {
+        const block = world.getBlock(cursor)
+        if (block == null) return null
+        if (!isWaterBlock(block, ids)) continue
+        const fluidHeight = cursor.y + getFluidHeight(block, world, cursor, ids)
+        if (bb.minY < fluidHeight) {
+          return true
+        }
+      }
+    }
+  }
+
+  return false
+}
+
+export function getRemoteBoatWaterPatchVisible (
+  entity: BoatEntityLike,
+  world: WorldLike,
+  ids: WaterIds,
+): boolean {
+  if (!isBoatEntityName(entity.name)) return false
+  const bb = getEntityBB(entity)
+  const underwater = isUnderwater(bb, world, ids)
+  if (underwater == null) return false
+  if (underwater) return false
+  const inWater = isInWater(bb, world, ids)
+  if (inWater == null) return false
+  return inWater
+}
+
+export function getLocalBoatWaterPatchVisible (status: BoatStatus | null | undefined): boolean {
+  return status === BoatStatus.IN_WATER
+}
+
+export function buildEntityRenderHints (
+  entity: BoatEntityLike & { id?: number },
+  options: {
+    localVehicle: BoatEntityLike | null | undefined
+    localBoatStatus: BoatStatus | null | undefined
+    world: WorldLike
+    waterIds: WaterIds
+  },
+) {
+  const renderHints: {
+    localVehicle?: boolean
+    boatWaterPatchVisible?: boolean
+  } = {}
+  if (options.localVehicle && entity === options.localVehicle) {
+    renderHints.localVehicle = true
+  }
+  if (!isBoatEntityName(entity.name)) {
+    return renderHints
+  }
+  if (renderHints.localVehicle) {
+    renderHints.boatWaterPatchVisible = getLocalBoatWaterPatchVisible(options.localBoatStatus)
+  } else {
+    renderHints.boatWaterPatchVisible = getRemoteBoatWaterPatchVisible(entity, options.world, options.waterIds)
+  }
+  return renderHints
+}

--- a/src/boatRenderHints.ts
+++ b/src/boatRenderHints.ts
@@ -25,6 +25,7 @@ type WaterIds = {
 
 export type VehicleRenderHints = {
   localVehicle?: boolean
+  localVehicleVerticalCameraLock?: 'horse'
   passengerIds?: number[]
   passengerLayout?: 'boat' | 'minecart' | 'horse'
   boatWaterPatchVisible?: boolean
@@ -187,6 +188,7 @@ export function buildEntityRenderHints (
   options: {
     localVehicle: VehicleEntityLike | null | undefined
     localBoatStatus: BoatStatus | null | undefined
+    horseControllerActive: boolean
     world: WorldLike
     waterIds: WaterIds
   },
@@ -223,6 +225,9 @@ export function buildEntityRenderHints (
   if (isRideableHorseEntityName(entity.name)) {
     renderHints.passengerIds = passengerIds
     renderHints.passengerLayout = 'horse'
+    if (renderHints.localVehicle === true && options.horseControllerActive) {
+      renderHints.localVehicleVerticalCameraLock = 'horse'
+    }
   }
 
   return renderHints

--- a/src/boatRenderHints.ts
+++ b/src/boatRenderHints.ts
@@ -26,6 +26,7 @@ type WaterIds = {
 export type VehicleRenderHints = {
   localVehicle?: boolean
   localVehicleVerticalCameraLock?: 'horse'
+  localVehicleYawLock?: 'horse'
   passengerIds?: number[]
   passengerLayout?: 'boat' | 'minecart' | 'horse'
   boatWaterPatchVisible?: boolean
@@ -300,6 +301,7 @@ export function buildEntityRenderHints (
     renderHints.passengerLayout = 'horse'
     if (renderHints.localVehicle === true && options.horseControllerActive) {
       renderHints.localVehicleVerticalCameraLock = 'horse'
+      renderHints.localVehicleYawLock = 'horse'
     }
   }
 

--- a/src/boatRenderHints.ts
+++ b/src/boatRenderHints.ts
@@ -74,7 +74,7 @@ function isWaterBlock (block: Block | null | undefined, ids: WaterIds): block is
 
 function isSourceWater (block: Block, ids: WaterIds): boolean {
   if (block.getProperties?.().waterlogged) return true
-  if (block.type !== ids.waterId) return true
+  if (block.type !== ids.waterId) return false
   return Number(block.getProperties?.().level ?? 0) === 0
 }
 
@@ -176,8 +176,10 @@ export function buildEntityRenderHints (
   },
 ): VehicleRenderHints {
   const renderHints: VehicleRenderHints = {}
-  const isLocalControlledBoat = options.localVehicle === entity && isBoatEntityName(entity.name)
-  if (isLocalControlledBoat) {
+  const isLocalVehicle = options.localVehicle === entity && (
+    isBoatEntityName(entity.name) || isRideableMinecartEntityName(entity.name)
+  )
+  if (isLocalVehicle) {
     renderHints.localVehicle = true
   }
 

--- a/src/cameraMovementMode.test.ts
+++ b/src/cameraMovementMode.test.ts
@@ -9,4 +9,5 @@ test('minecart vehicle selects server-vehicle camera mode', () => {
 test('walking player uses local-player camera mode', () => {
   expect(getCameraMovementMode({ vehicle: null })).toBe('local-player')
   expect(getCameraMovementMode({ vehicle: { name: 'boat' } })).toBe('local-player')
+  expect(getCameraMovementMode({ vehicle: { name: 'horse' } })).toBe('local-player')
 })

--- a/src/cameraMovementMode.test.ts
+++ b/src/cameraMovementMode.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'vitest'
+import { getCameraMovementMode } from './cameraMovementMode'
+
+test('minecart vehicle selects server-vehicle camera mode', () => {
+  expect(getCameraMovementMode({ vehicle: { name: 'minecart' } })).toBe('server-vehicle')
+  expect(getCameraMovementMode({ vehicle: { name: 'chest_minecart' } })).toBe('server-vehicle')
+})
+
+test('walking player uses local-player camera mode', () => {
+  expect(getCameraMovementMode({ vehicle: null })).toBe('local-player')
+  expect(getCameraMovementMode({ vehicle: { name: 'boat' } })).toBe('local-player')
+})

--- a/src/cameraMovementMode.ts
+++ b/src/cameraMovementMode.ts
@@ -1,0 +1,9 @@
+import type { CameraMovementMode } from 'minecraft-renderer/src/graphicsBackend/types'
+import { isRideableMinecartEntityName } from './boatRenderHints'
+
+export function getCameraMovementMode (bot: { vehicle?: { name?: string } | null }): CameraMovementMode {
+  if (bot.vehicle && isRideableMinecartEntityName(bot.vehicle.name)) {
+    return 'server-vehicle'
+  }
+  return 'local-player'
+}

--- a/src/cameraRotationControls.test.ts
+++ b/src/cameraRotationControls.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'vitest'
+import { getClampedBoatPassengerYaw, isBoatEntityName } from '../../minecraft-renderer/src/three/entity/boatPassengerRotation'
+
+const BOAT_YAW = 1.0
+
+function resolveBoatPassengerLookYaw (requestedYaw: number, vehicle: { name: string; yaw: number } | null): number {
+  if (!vehicle || !isBoatEntityName(vehicle.name)) return requestedYaw
+  const boatYaw = vehicle.yaw
+  if (!Number.isFinite(boatYaw) || !Number.isFinite(requestedYaw)) return requestedYaw
+  return getClampedBoatPassengerYaw(requestedYaw, boatYaw)
+}
+
+test('camera controls clamp boat look yaw before look/updateCamera', () => {
+  const vehicle = { name: 'boat', yaw: BOAT_YAW }
+  const requested = BOAT_YAW + 2.5
+  const clamped = resolveBoatPassengerLookYaw(requested, vehicle)
+  expect(clamped).toBeLessThan(requested)
+  expect(clamped - BOAT_YAW).toBeCloseTo((105 * Math.PI) / 180)
+})
+
+test('camera controls leave minecart look yaw unchanged', () => {
+  const vehicle = { name: 'minecart', yaw: BOAT_YAW }
+  const requested = BOAT_YAW + 2.5
+  expect(resolveBoatPassengerLookYaw(requested, vehicle)).toBe(requested)
+})
+
+test('camera controls fallback when vehicle missing', () => {
+  expect(resolveBoatPassengerLookYaw(1.75, null)).toBe(1.75)
+})

--- a/src/cameraRotationControls.ts
+++ b/src/cameraRotationControls.ts
@@ -1,3 +1,4 @@
+import { getClampedBoatPassengerYaw, isBoatEntityName } from 'minecraft-renderer/src/three/entity/boatPassengerRotation'
 import { getPlayerStateUtils } from 'minecraft-renderer/src'
 import { contro } from './controls'
 import { activeModalStack, isGameActive, miscUiState, showModal } from './globalState'
@@ -49,8 +50,18 @@ export const moveCameraRawHandler = ({ x, y }: { x: number; y: number }) => {
 
   if (!bot?.entity) return
   const pitch = bot.entity.pitch - y
-  void bot.look(bot.entity.yaw - x, Math.max(minPitch, Math.min(maxPitch, pitch)), true)
-  appViewer.backend?.updateCamera(null, bot.entity.yaw, pitch)
+  const requestedYaw = bot.entity.yaw - x
+  const clampedYaw = resolveBoatPassengerLookYaw(requestedYaw)
+  void bot.look(clampedYaw, Math.max(minPitch, Math.min(maxPitch, pitch)), true)
+  appViewer.backend?.updateCamera(null, clampedYaw, pitch)
+}
+
+function resolveBoatPassengerLookYaw (requestedYaw: number): number {
+  const vehicle = bot.vehicle
+  if (!vehicle || !isBoatEntityName(vehicle.name)) return requestedYaw
+  const boatYaw = vehicle.yaw
+  if (!Number.isFinite(boatYaw) || !Number.isFinite(requestedYaw)) return requestedYaw
+  return getClampedBoatPassengerYaw(requestedYaw, boatYaw)
 }
 
 window.addEventListener('mousemove', (e: MouseEvent) => {

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -9,8 +9,11 @@ import { getPlayerStateUtils } from 'minecraft-renderer/src'
 import { options, watchValue } from './optionsStorage'
 import { gameAdditionalState, miscUiState } from './globalState'
 import { EntityStatus } from './mineflayer/entityStatus'
-import { getEntityMovementAnimation } from './entityMovementAnimation'
-import { isRideableHorseEntityName } from './boatRenderHints'
+import {
+  applyEntityMovementAnimation,
+  clearLocalPlayerAnimationCache,
+  processMovementAnimations,
+} from './entityMovementAnimationPipeline'
 
 
 const updateAutoJump = () => {
@@ -64,33 +67,59 @@ customEvents.on('gameLoaded', () => {
   }
 
   let lastCall = 0
+
+  const applyLocalPlayerAnimation = (force = false) => {
+    if (!bot.entity) return
+    const rendererMethods = getThreeJsRendererMethods()
+    applyEntityMovementAnimation({
+      entity: bot.entity,
+      horizontalVelocity: bot.entity.velocity,
+      rendererEntityId: 'player_entity',
+      mountedVehicle: bot.vehicle,
+      force,
+      isLocalPlayer: true,
+      isLocalPlayerSneaking: gameAdditionalState.isSneaking,
+      playerPerAnimation,
+      playEntityAnimation: (rendererEntityId, animation) => {
+        void rendererMethods?.playEntityAnimation(rendererEntityId, animation)
+      },
+      rendererAvailable: rendererMethods != null,
+    })
+  }
+
   bot.on('physicsTick', () => {
     // throttle, tps: 6
     if (Date.now() - lastCall < 166) return
     lastCall = Date.now()
-    for (const [id, { tracking, info }] of Object.entries(bot.tracker.trackingData)) {
-      if (!tracking) continue
-      const e = bot.entities[id]
-      if (!e) continue
-      const speed = info.avgVel
-      const isCrouched = e === bot.entity ? gameAdditionalState.isSneaking : e['crouching']
 
-      const newAnimation = getEntityMovementAnimation({
-        isMounted: e.vehicle !== null && e.vehicle !== undefined,
-        isHorseMounted: e.vehicle !== null && e.vehicle !== undefined && isRideableHorseEntityName(e.vehicle.name),
-        isCrouched,
-        horizontalVelocity: speed,
-      })
-      if (newAnimation !== playerPerAnimation[id]) {
-        // Handle bot entity animation specially (for player entity in third person)
-        if (e === bot.entity) {
-          getThreeJsRendererMethods()?.playEntityAnimation('player_entity', newAnimation)
-        } else {
-          getThreeJsRendererMethods()?.playEntityAnimation(e.id, newAnimation)
-        }
-        playerPerAnimation[id] = newAnimation
-      }
-    }
+    const rendererMethods = getThreeJsRendererMethods()
+    processMovementAnimations({
+      localPlayerEntity: bot.entity ?? null,
+      localPlayerVehicle: bot.vehicle ?? null,
+      isLocalPlayerSneaking: gameAdditionalState.isSneaking,
+      trackingData: bot.tracker.trackingData,
+      getEntityById: (id) => bot.entities[id],
+      playerPerAnimation,
+      playEntityAnimation: (rendererEntityId, animation) => {
+        void rendererMethods?.playEntityAnimation(rendererEntityId, animation)
+      },
+      rendererAvailable: rendererMethods != null,
+    })
+  })
+
+  bot.on('mount', () => {
+    applyLocalPlayerAnimation()
+  })
+
+  bot.on('dismount', () => {
+    applyLocalPlayerAnimation()
+  })
+
+  bot.on('respawn', () => {
+    clearLocalPlayerAnimationCache(playerPerAnimation)
+    queueMicrotask(() => {
+      applyLocalPlayerAnimation(true)
+    })
   })
 
   bot.on('entitySwingArm', (e) => {

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -10,6 +10,7 @@ import { options, watchValue } from './optionsStorage'
 import { gameAdditionalState, miscUiState } from './globalState'
 import { EntityStatus } from './mineflayer/entityStatus'
 import { getEntityMovementAnimation } from './entityMovementAnimation'
+import { isRideableHorseEntityName } from './boatRenderHints'
 
 
 const updateAutoJump = () => {
@@ -75,7 +76,8 @@ customEvents.on('gameLoaded', () => {
       const isCrouched = e === bot.entity ? gameAdditionalState.isSneaking : e['crouching']
 
       const newAnimation = getEntityMovementAnimation({
-        isMounted: e.vehicle != null,
+        isMounted: e.vehicle !== null && e.vehicle !== undefined,
+        isHorseMounted: e.vehicle !== null && e.vehicle !== undefined && isRideableHorseEntityName(e.vehicle.name),
         isCrouched,
         horizontalVelocity: speed,
       })

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -9,6 +9,7 @@ import { getPlayerStateUtils } from 'minecraft-renderer/src'
 import { options, watchValue } from './optionsStorage'
 import { gameAdditionalState, miscUiState } from './globalState'
 import { EntityStatus } from './mineflayer/entityStatus'
+import { getEntityMovementAnimation } from './entityMovementAnimation'
 
 
 const updateAutoJump = () => {
@@ -71,16 +72,13 @@ customEvents.on('gameLoaded', () => {
       const e = bot.entities[id]
       if (!e) continue
       const speed = info.avgVel
-      const WALKING_SPEED = 0.03
-      const SPRINTING_SPEED = 0.18
       const isCrouched = e === bot.entity ? gameAdditionalState.isSneaking : e['crouching']
-      const isWalking = Math.abs(speed.x) > WALKING_SPEED || Math.abs(speed.z) > WALKING_SPEED
-      const isSprinting = Math.abs(speed.x) > SPRINTING_SPEED || Math.abs(speed.z) > SPRINTING_SPEED
 
-      const newAnimation =
-        isCrouched ? (isWalking ? 'crouchWalking' : 'crouch')
-          : isWalking ? (isSprinting ? 'running' : 'walking')
-            : 'idle'
+      const newAnimation = getEntityMovementAnimation({
+        isMounted: e.vehicle != null,
+        isCrouched,
+        horizontalVelocity: speed,
+      })
       if (newAnimation !== playerPerAnimation[id]) {
         // Handle bot entity animation specially (for player entity in third person)
         if (e === bot.entity) {

--- a/src/entityMovementAnimation.test.ts
+++ b/src/entityMovementAnimation.test.ts
@@ -5,29 +5,28 @@ const walkingVelocity = { x: 0.05, z: 0 }
 const sprintingVelocity = { x: 0.25, z: 0 }
 const highVehicleVelocity = { x: 1.5, z: 0.8 }
 
-test('mounted horse player uses riding animation', () => {
+test('mounted player with zero speed uses riding', () => {
   expect(getEntityMovementAnimation({
     isMounted: true,
-    isHorseMounted: true,
+    isCrouched: false,
+    horizontalVelocity: { x: 0, z: 0 },
+  })).toBe('riding')
+})
+
+test('mounted player with high vehicle speed uses riding', () => {
+  expect(getEntityMovementAnimation({
+    isMounted: true,
     isCrouched: false,
     horizontalVelocity: highVehicleVelocity,
   })).toBe('riding')
 })
 
-test('mounted player with high vehicle speed uses idle', () => {
+test('mounted crouched player uses riding', () => {
   expect(getEntityMovementAnimation({
     isMounted: true,
-    isCrouched: false,
-    horizontalVelocity: highVehicleVelocity,
-  })).toBe('idle')
-})
-
-test('mounted player with zero speed uses idle', () => {
-  expect(getEntityMovementAnimation({
-    isMounted: true,
-    isCrouched: false,
-    horizontalVelocity: { x: 0, z: 0 },
-  })).toBe('idle')
+    isCrouched: true,
+    horizontalVelocity: walkingVelocity,
+  })).toBe('riding')
 })
 
 test('unmounted walking speed uses walking', () => {

--- a/src/entityMovementAnimation.test.ts
+++ b/src/entityMovementAnimation.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from 'vitest'
+import { getEntityMovementAnimation } from './entityMovementAnimation'
+
+const walkingVelocity = { x: 0.05, z: 0 }
+const sprintingVelocity = { x: 0.25, z: 0 }
+const highVehicleVelocity = { x: 1.5, z: 0.8 }
+
+test('mounted player with high vehicle speed uses idle', () => {
+  expect(getEntityMovementAnimation({
+    isMounted: true,
+    isCrouched: false,
+    horizontalVelocity: highVehicleVelocity,
+  })).toBe('idle')
+})
+
+test('mounted player with zero speed uses idle', () => {
+  expect(getEntityMovementAnimation({
+    isMounted: true,
+    isCrouched: false,
+    horizontalVelocity: { x: 0, z: 0 },
+  })).toBe('idle')
+})
+
+test('unmounted walking speed uses walking', () => {
+  expect(getEntityMovementAnimation({
+    isMounted: false,
+    isCrouched: false,
+    horizontalVelocity: walkingVelocity,
+  })).toBe('walking')
+})
+
+test('unmounted sprinting speed uses running', () => {
+  expect(getEntityMovementAnimation({
+    isMounted: false,
+    isCrouched: false,
+    horizontalVelocity: sprintingVelocity,
+  })).toBe('running')
+})
+
+test('unmounted crouched movement uses crouchWalking', () => {
+  expect(getEntityMovementAnimation({
+    isMounted: false,
+    isCrouched: true,
+    horizontalVelocity: walkingVelocity,
+  })).toBe('crouchWalking')
+})
+
+test('unmounted stationary crouch uses crouch', () => {
+  expect(getEntityMovementAnimation({
+    isMounted: false,
+    isCrouched: true,
+    horizontalVelocity: { x: 0, z: 0 },
+  })).toBe('crouch')
+})

--- a/src/entityMovementAnimation.test.ts
+++ b/src/entityMovementAnimation.test.ts
@@ -5,6 +5,15 @@ const walkingVelocity = { x: 0.05, z: 0 }
 const sprintingVelocity = { x: 0.25, z: 0 }
 const highVehicleVelocity = { x: 1.5, z: 0.8 }
 
+test('mounted horse player uses riding animation', () => {
+  expect(getEntityMovementAnimation({
+    isMounted: true,
+    isHorseMounted: true,
+    isCrouched: false,
+    horizontalVelocity: highVehicleVelocity,
+  })).toBe('riding')
+})
+
 test('mounted player with high vehicle speed uses idle', () => {
   expect(getEntityMovementAnimation({
     isMounted: true,

--- a/src/entityMovementAnimation.ts
+++ b/src/entityMovementAnimation.ts
@@ -2,14 +2,12 @@ export type EntityMovementAnimation = 'idle' | 'walking' | 'running' | 'crouch' 
 
 export type EntityMovementAnimationInput = {
   isMounted: boolean
-  isHorseMounted?: boolean
   isCrouched: boolean
   horizontalVelocity: { x: number; z: number }
 }
 
 export function getEntityMovementAnimation (input: EntityMovementAnimationInput): EntityMovementAnimation {
-  if (input.isHorseMounted) return 'riding'
-  if (input.isMounted) return 'idle'
+  if (input.isMounted) return 'riding'
 
   const WALKING_SPEED = 0.03
   const SPRINTING_SPEED = 0.18

--- a/src/entityMovementAnimation.ts
+++ b/src/entityMovementAnimation.ts
@@ -1,0 +1,26 @@
+export type EntityMovementAnimation = 'idle' | 'walking' | 'running' | 'crouch' | 'crouchWalking'
+
+const WALKING_SPEED = 0.03
+const SPRINTING_SPEED = 0.18
+
+export type EntityMovementAnimationInput = {
+  isMounted: boolean
+  isCrouched: boolean
+  horizontalVelocity: { x: number; z: number }
+}
+
+export function getEntityMovementAnimation (input: EntityMovementAnimationInput): EntityMovementAnimation {
+  if (input.isMounted) return 'idle'
+
+  const { x, z } = input.horizontalVelocity
+  const isWalking = Math.abs(x) > WALKING_SPEED || Math.abs(z) > WALKING_SPEED
+  const isSprinting = Math.abs(x) > SPRINTING_SPEED || Math.abs(z) > SPRINTING_SPEED
+
+  if (input.isCrouched) {
+    return isWalking ? 'crouchWalking' : 'crouch'
+  }
+  if (isWalking) {
+    return isSprinting ? 'running' : 'walking'
+  }
+  return 'idle'
+}

--- a/src/entityMovementAnimation.ts
+++ b/src/entityMovementAnimation.ts
@@ -1,16 +1,18 @@
-export type EntityMovementAnimation = 'idle' | 'walking' | 'running' | 'crouch' | 'crouchWalking'
-
-const WALKING_SPEED = 0.03
-const SPRINTING_SPEED = 0.18
+export type EntityMovementAnimation = 'idle' | 'walking' | 'running' | 'crouch' | 'crouchWalking' | 'riding'
 
 export type EntityMovementAnimationInput = {
   isMounted: boolean
+  isHorseMounted?: boolean
   isCrouched: boolean
   horizontalVelocity: { x: number; z: number }
 }
 
 export function getEntityMovementAnimation (input: EntityMovementAnimationInput): EntityMovementAnimation {
+  if (input.isHorseMounted) return 'riding'
   if (input.isMounted) return 'idle'
+
+  const WALKING_SPEED = 0.03
+  const SPRINTING_SPEED = 0.18
 
   const { x, z } = input.horizontalVelocity
   const isWalking = Math.abs(x) > WALKING_SPEED || Math.abs(z) > WALKING_SPEED

--- a/src/entityMovementAnimationPipeline.test.ts
+++ b/src/entityMovementAnimationPipeline.test.ts
@@ -1,0 +1,258 @@
+import { expect, test } from 'vitest'
+import {
+  applyEntityMovementAnimation,
+  clearLocalPlayerAnimationCache,
+  isLocalPlayerMounted,
+  processMovementAnimations,
+  sanitizeHorizontalVelocity,
+  shouldProcessRemoteTrackingEntry,
+  shouldTrackPlayerEntity,
+} from './entityMovementAnimationPipeline'
+
+const walkingVelocity = { x: 0.05, z: 0 }
+const localPlayer = { id: 1, velocity: walkingVelocity, vehicle: null, type: 'player', username: 'local' }
+const remotePlayer = { id: 2, velocity: { x: 0, z: 0 }, vehicle: null, type: 'player', username: 'remote' }
+
+function makePlaySpy () {
+  const calls: Array<{ id: number | 'player_entity'; animation: string }> = []
+  return {
+    calls,
+    playEntityAnimation: (id: number | 'player_entity', animation: string) => {
+      calls.push({ id, animation })
+    },
+  }
+}
+
+test('local player gets walking from bot.entity.velocity with empty trackingData', () => {
+  const playerPerAnimation = {}
+  const { calls, playEntityAnimation } = makePlaySpy()
+
+  processMovementAnimations({
+    localPlayerEntity: localPlayer,
+    isLocalPlayerSneaking: false,
+    trackingData: {},
+    getEntityById: () => undefined,
+    playerPerAnimation,
+    playEntityAnimation,
+    rendererAvailable: true,
+  })
+
+  expect(calls).toEqual([{ id: 'player_entity', animation: 'walking' }])
+})
+
+test('local player gets riding when only bot.vehicle is set', () => {
+  const vehicle = { id: 99, name: 'boat' }
+  const playerPerAnimation = {}
+  const { calls, playEntityAnimation } = makePlaySpy()
+
+  processMovementAnimations({
+    localPlayerEntity: { ...localPlayer, velocity: { x: 0, z: 0 }, vehicle: null },
+    localPlayerVehicle: vehicle,
+    isLocalPlayerSneaking: false,
+    trackingData: {},
+    getEntityById: () => undefined,
+    playerPerAnimation,
+    playEntityAnimation,
+    rendererAvailable: true,
+  })
+
+  expect(calls).toEqual([{ id: 'player_entity', animation: 'riding' }])
+})
+
+test('local player gets riding when only bot.entity.vehicle is set', () => {
+  const vehicle = { id: 99, name: 'boat' }
+  const playerPerAnimation = {}
+  const { calls, playEntityAnimation } = makePlaySpy()
+
+  processMovementAnimations({
+    localPlayerEntity: { ...localPlayer, velocity: { x: 0, z: 0 }, vehicle },
+    localPlayerVehicle: null,
+    isLocalPlayerSneaking: false,
+    trackingData: {},
+    getEntityById: () => undefined,
+    playerPerAnimation,
+    playEntityAnimation,
+    rendererAvailable: true,
+  })
+
+  expect(calls).toEqual([{ id: 'player_entity', animation: 'riding' }])
+})
+
+test('local animation does not depend on bot.entities presence', () => {
+  const playerPerAnimation = {}
+  const { calls, playEntityAnimation } = makePlaySpy()
+
+  processMovementAnimations({
+    localPlayerEntity: localPlayer,
+    isLocalPlayerSneaking: false,
+    trackingData: {},
+    getEntityById: () => undefined,
+    playerPerAnimation,
+    playEntityAnimation,
+    rendererAvailable: true,
+  })
+
+  expect(calls).toHaveLength(1)
+  expect(isLocalPlayerMounted(localPlayer, null)).toBe(false)
+})
+
+test('local player is not processed again in remote loop', () => {
+  const playerPerAnimation = {}
+  const { calls, playEntityAnimation } = makePlaySpy()
+
+  processMovementAnimations({
+    localPlayerEntity: localPlayer,
+    isLocalPlayerSneaking: false,
+    trackingData: {
+      '1': { tracking: true, info: { avgVel: { x: 0, z: 0 } } },
+      '2': { tracking: true, info: { avgVel: walkingVelocity } },
+    },
+    getEntityById: (id) => {
+      if (id === '1') return localPlayer
+      if (id === '2') return remotePlayer
+      return undefined
+    },
+    playerPerAnimation,
+    playEntityAnimation,
+    rendererAvailable: true,
+  })
+
+  expect(calls.filter(c => c.id === 'player_entity')).toHaveLength(1)
+  expect(calls.some(c => c.id === 2 && c.animation === 'walking')).toBe(true)
+})
+
+test('invalid remote avgVel becomes zero velocity', () => {
+  expect(sanitizeHorizontalVelocity({ x: Number.NaN, z: null as unknown as number })).toEqual({ x: 0, z: 0 })
+})
+
+test('same animation command is not sent again without force', () => {
+  const playerPerAnimation = {}
+  const { calls, playEntityAnimation } = makePlaySpy()
+
+  const params = {
+    entity: localPlayer,
+    horizontalVelocity: walkingVelocity,
+    rendererEntityId: 'player_entity' as const,
+    isLocalPlayer: true,
+    isLocalPlayerSneaking: false,
+    playerPerAnimation,
+    playEntityAnimation,
+    rendererAvailable: true,
+  }
+
+  expect(applyEntityMovementAnimation(params)).toBe(true)
+  expect(applyEntityMovementAnimation(params)).toBe(false)
+  expect(calls).toHaveLength(1)
+})
+
+test('animation is not cached when renderer is unavailable', () => {
+  const playerPerAnimation = {}
+  const { calls, playEntityAnimation } = makePlaySpy()
+
+  expect(applyEntityMovementAnimation({
+    entity: localPlayer,
+    horizontalVelocity: walkingVelocity,
+    rendererEntityId: 'player_entity',
+    isLocalPlayer: true,
+    isLocalPlayerSneaking: false,
+    playerPerAnimation,
+    playEntityAnimation,
+    rendererAvailable: false,
+  })).toBe(false)
+
+  expect(playerPerAnimation['player_entity']).toBeUndefined()
+  expect(calls).toHaveLength(0)
+})
+
+test('after cache clear the animation command is sent again', () => {
+  const playerPerAnimation = {}
+  const { calls, playEntityAnimation } = makePlaySpy()
+
+  const params = {
+    entity: { ...localPlayer, velocity: { x: 0, z: 0 } },
+    horizontalVelocity: { x: 0, z: 0 },
+    rendererEntityId: 'player_entity' as const,
+    isLocalPlayer: true,
+    isLocalPlayerSneaking: false,
+    playerPerAnimation,
+    playEntityAnimation,
+    rendererAvailable: true,
+  }
+
+  applyEntityMovementAnimation(params)
+  applyEntityMovementAnimation(params)
+  clearLocalPlayerAnimationCache(playerPerAnimation)
+  applyEntityMovementAnimation({ ...params, force: true })
+
+  expect(calls).toHaveLength(2)
+})
+
+test('mount immediately sends riding', () => {
+  const vehicle = { id: 99, name: 'horse' }
+  const playerPerAnimation = {}
+  const { calls, playEntityAnimation } = makePlaySpy()
+
+  applyEntityMovementAnimation({
+    entity: localPlayer,
+    horizontalVelocity: walkingVelocity,
+    rendererEntityId: 'player_entity',
+    mountedVehicle: vehicle,
+    isLocalPlayer: true,
+    isLocalPlayerSneaking: false,
+    playerPerAnimation,
+    playEntityAnimation,
+    rendererAvailable: true,
+  })
+
+  expect(calls).toEqual([{ id: 'player_entity', animation: 'riding' }])
+})
+
+test('dismount immediately sends current movement animation', () => {
+  const playerPerAnimation = { player_entity: 'riding' }
+  const { calls, playEntityAnimation } = makePlaySpy()
+
+  applyEntityMovementAnimation({
+    entity: { ...localPlayer, vehicle: null },
+    horizontalVelocity: walkingVelocity,
+    rendererEntityId: 'player_entity',
+    mountedVehicle: null,
+    isLocalPlayer: true,
+    isLocalPlayerSneaking: false,
+    playerPerAnimation,
+    playEntityAnimation,
+    rendererAvailable: true,
+  })
+
+  expect(calls).toEqual([{ id: 'player_entity', animation: 'walking' }])
+})
+
+test('remote entityGone then entitySpawn becomes eligible for tracking loop again', () => {
+  expect(shouldTrackPlayerEntity(remotePlayer)).toBe(true)
+  expect(shouldProcessRemoteTrackingEntry({
+    tracking: true,
+    entity: undefined,
+    localPlayerEntity: localPlayer,
+  })).toBe(false)
+  expect(shouldProcessRemoteTrackingEntry({
+    tracking: true,
+    entity: remotePlayer,
+    localPlayerEntity: localPlayer,
+  })).toBe(true)
+})
+
+test('local entityGone does not stop local animation updates', () => {
+  const playerPerAnimation = {}
+  const { calls, playEntityAnimation } = makePlaySpy()
+
+  processMovementAnimations({
+    localPlayerEntity: localPlayer,
+    isLocalPlayerSneaking: false,
+    trackingData: {},
+    getEntityById: () => undefined,
+    playerPerAnimation,
+    playEntityAnimation,
+    rendererAvailable: true,
+  })
+
+  expect(calls).toEqual([{ id: 'player_entity', animation: 'walking' }])
+})

--- a/src/entityMovementAnimationPipeline.ts
+++ b/src/entityMovementAnimationPipeline.ts
@@ -1,0 +1,178 @@
+import {
+  EntityMovementAnimation,
+  getEntityMovementAnimation,
+} from './entityMovementAnimation'
+
+export const LOCAL_PLAYER_RENDERER_ID = 'player_entity' as const
+export const LOCAL_PLAYER_CACHE_KEY = 'player_entity'
+
+export type HorizontalVelocity = { x: number; z: number }
+export type RendererEntityId = number | typeof LOCAL_PLAYER_RENDERER_ID
+export type AnimationCache = Record<string, string>
+
+export type EntityLike = {
+  id?: number
+  vehicle?: EntityLike | null
+  crouching?: boolean
+  username?: string
+  type?: string
+}
+
+export type TrackingDataEntry = {
+  tracking: boolean
+  info: { avgVel: Partial<HorizontalVelocity> }
+}
+
+export function sanitizeHorizontalVelocity (
+  velocity: Partial<HorizontalVelocity> | null | undefined,
+): HorizontalVelocity {
+  const x = velocity?.x
+  const z = velocity?.z
+  return {
+    x: Number.isFinite(x) ? x! : 0,
+    z: Number.isFinite(z) ? z! : 0,
+  }
+}
+
+export function isLocalPlayerMounted (
+  entity: EntityLike,
+  mountedVehicle?: EntityLike | null,
+): boolean {
+  return Boolean(entity.vehicle ?? mountedVehicle)
+}
+
+export function getIsCrouched (
+  entity: EntityLike,
+  isLocalPlayer: boolean,
+  isLocalPlayerSneaking: boolean,
+): boolean {
+  return isLocalPlayer ? isLocalPlayerSneaking : Boolean(entity.crouching)
+}
+
+export function resolveCacheKey (rendererEntityId: RendererEntityId): string {
+  return String(rendererEntityId)
+}
+
+export function shouldTrackPlayerEntity (entity: EntityLike): boolean {
+  return Boolean(entity.username) && entity.type === 'player'
+}
+
+export function shouldProcessRemoteTrackingEntry (params: {
+  tracking: boolean
+  entity: EntityLike | null | undefined
+  localPlayerEntity: EntityLike | null | undefined
+}): boolean {
+  const { tracking, entity, localPlayerEntity } = params
+  if (!tracking) return false
+  if (!entity) return false
+  if (entity === localPlayerEntity) return false
+  return true
+}
+
+export type ApplyEntityMovementAnimationParams = {
+  entity: EntityLike
+  horizontalVelocity: Partial<HorizontalVelocity>
+  rendererEntityId: RendererEntityId
+  mountedVehicle?: EntityLike | null
+  force?: boolean
+  isLocalPlayer: boolean
+  isLocalPlayerSneaking: boolean
+  playerPerAnimation: AnimationCache
+  playEntityAnimation: (rendererEntityId: RendererEntityId, animation: EntityMovementAnimation) => void | Promise<void> | undefined
+  rendererAvailable: boolean
+}
+
+export function applyEntityMovementAnimation (params: ApplyEntityMovementAnimationParams): boolean {
+  const {
+    entity,
+    horizontalVelocity,
+    rendererEntityId,
+    mountedVehicle,
+    force = false,
+    isLocalPlayer,
+    isLocalPlayerSneaking,
+    playerPerAnimation,
+    playEntityAnimation,
+    rendererAvailable,
+  } = params
+
+  const sanitizedVelocity = sanitizeHorizontalVelocity(horizontalVelocity)
+  const animation = getEntityMovementAnimation({
+    isMounted: isLocalPlayer
+      ? isLocalPlayerMounted(entity, mountedVehicle)
+      : Boolean(entity.vehicle ?? mountedVehicle),
+    isCrouched: getIsCrouched(entity, isLocalPlayer, isLocalPlayerSneaking),
+    horizontalVelocity: sanitizedVelocity,
+  })
+
+  const cacheKey = resolveCacheKey(rendererEntityId)
+  if (!force && playerPerAnimation[cacheKey] === animation) return false
+  if (!rendererAvailable) return false
+
+  void playEntityAnimation(rendererEntityId, animation)
+  playerPerAnimation[cacheKey] = animation
+  return true
+}
+
+export type ProcessMovementAnimationsParams = {
+  localPlayerEntity: (EntityLike & { velocity: Partial<HorizontalVelocity> }) | null
+  localPlayerVehicle?: EntityLike | null
+  isLocalPlayerSneaking: boolean
+  trackingData: Record<string, TrackingDataEntry>
+  getEntityById: (id: string) => (EntityLike & { id: number }) | undefined
+  playerPerAnimation: AnimationCache
+  playEntityAnimation: (rendererEntityId: RendererEntityId, animation: EntityMovementAnimation) => void | Promise<void> | undefined
+  rendererAvailable: boolean
+}
+
+export function processMovementAnimations (params: ProcessMovementAnimationsParams): void {
+  const {
+    localPlayerEntity,
+    localPlayerVehicle,
+    isLocalPlayerSneaking,
+    trackingData,
+    getEntityById,
+    playerPerAnimation,
+    playEntityAnimation,
+    rendererAvailable,
+  } = params
+
+  if (localPlayerEntity) {
+    applyEntityMovementAnimation({
+      entity: localPlayerEntity,
+      horizontalVelocity: localPlayerEntity.velocity,
+      rendererEntityId: LOCAL_PLAYER_RENDERER_ID,
+      mountedVehicle: localPlayerVehicle,
+      isLocalPlayer: true,
+      isLocalPlayerSneaking,
+      playerPerAnimation,
+      playEntityAnimation,
+      rendererAvailable,
+    })
+  }
+
+  for (const [id, trackerData] of Object.entries(trackingData)) {
+    const entity = getEntityById(id)
+    if (!shouldProcessRemoteTrackingEntry({
+      tracking: trackerData.tracking,
+      entity,
+      localPlayerEntity,
+    }) || !entity) continue
+
+    applyEntityMovementAnimation({
+      entity,
+      horizontalVelocity: trackerData.info.avgVel,
+      rendererEntityId: entity.id,
+      mountedVehicle: entity.vehicle,
+      isLocalPlayer: false,
+      isLocalPlayerSneaking: false,
+      playerPerAnimation,
+      playEntityAnimation,
+      rendererAvailable,
+    })
+  }
+}
+
+export function clearLocalPlayerAnimationCache (playerPerAnimation: AnimationCache): void {
+  delete playerPerAnimation[LOCAL_PLAYER_CACHE_KEY]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,7 @@ import { getCurrentProxy, getCurrentUsername } from './react/ServersList'
 import { versionToNumber } from 'mc-assets/dist/utils'
 import { isPlayground } from './playgroundIntegration'
 import { appLoadBackend } from './appViewerLoad'
+import { getCameraMovementMode } from './cameraMovementMode'
 import { FORBIDDEN_VERSION_THRESHOLD } from './supportedVersions.mjs'
 
 window.debug = debug
@@ -852,13 +853,18 @@ export async function connect (connectOptions: ConnectOptions) {
       initMotionTracking()
 
       // Bot position callback
-      const botPosition = () => {
+      const botPosition = (instant = false) => {
         appViewer.lastCamUpdate = Date.now()
-        // this might cause lag, but not sure
-        appViewer.backend?.updateCamera(bot.entity.position, bot.entity.yaw, bot.entity.pitch)
+        appViewer.backend?.updateCamera(
+          bot.entity.position,
+          bot.entity.yaw,
+          bot.entity.pitch,
+          { movementMode: getCameraMovementMode(bot), instant },
+        )
         void appViewer.worldView?.updatePosition(bot.entity.position)
       }
-      bot.on('move', botPosition)
+      bot.on('move', () => botPosition())
+      bot.on('forcedMove', () => botPosition(true))
       botPosition()
 
       progress.setMessage('Setting callbacks')

--- a/src/mineflayer/playerState.ts
+++ b/src/mineflayer/playerState.ts
@@ -6,6 +6,7 @@ import { HandItemBlock } from 'minecraft-renderer/src/playerState/types'
 import { beforeRenderFrame } from '../beforeRenderFrame'
 import { gameAdditionalState } from '../globalState'
 import { options } from '../optionsStorage'
+import { getCameraMovementMode } from '../cameraMovementMode'
 
 const BASE_MOVEMENT_SPEED = 0.1
 const FOV_EFFECT_SCALE = 1
@@ -320,7 +321,9 @@ export class PlayerStateControllerMain {
     if (this.eyeHeightWatchInstalled) return
     this.eyeHeightWatchInstalled = true
     subscribeKey(this.reactive, 'eyeHeight', () => {
-      appViewer.backend?.updateCamera(bot.entity.position, bot.entity.yaw, bot.entity.pitch)
+      appViewer.backend?.updateCamera(bot.entity.position, bot.entity.yaw, bot.entity.pitch, {
+        movementMode: getCameraMovementMode(bot),
+      })
     })
   }
 

--- a/src/mineflayer/playerState.ts
+++ b/src/mineflayer/playerState.ts
@@ -7,6 +7,7 @@ import { beforeRenderFrame } from '../beforeRenderFrame'
 import { gameAdditionalState } from '../globalState'
 import { options } from '../optionsStorage'
 import { getCameraMovementMode } from '../cameraMovementMode'
+import { updateMountedBobState, updateMountedMovementState } from '../mountedPlayerState'
 
 const BASE_MOVEMENT_SPEED = 0.1
 const FOV_EFFECT_SCALE = 1
@@ -223,32 +224,22 @@ export class PlayerStateControllerMain {
 
     const { velocity } = bot.entity
     const isOnGround = bot.entity.onGround
-    const VELOCITY_THRESHOLD = 0.01
-    const SPRINTING_VELOCITY = 0.15
-    const OFF_GROUND_THRESHOLD = 0 // ms before switching to SNEAKING when off ground
 
     const now = performance.now()
     const deltaTime = now - this.lastUpdateTime
     this.lastUpdateTime = now
 
-    // this.lastVelocity = velocity
-
-    // Update time off ground
-    if (isOnGround) {
-      this.timeOffGround = 0
-    } else {
-      this.timeOffGround += deltaTime
-    }
-
-    if (gameAdditionalState.isSneaking || gameAdditionalState.isFlying || (this.timeOffGround > OFF_GROUND_THRESHOLD)) {
-      this.reactive.movementState = 'SNEAKING'
-    } else if (Math.abs(velocity.x) > VELOCITY_THRESHOLD || Math.abs(velocity.z) > VELOCITY_THRESHOLD) {
-      this.reactive.movementState = Math.abs(velocity.x) > SPRINTING_VELOCITY || Math.abs(velocity.z) > SPRINTING_VELOCITY
-        ? 'SPRINTING'
-        : 'WALKING'
-    } else {
-      this.reactive.movementState = 'NOT_MOVING'
-    }
+    const next = updateMountedMovementState({
+      mounted: Boolean(bot.vehicle),
+      velocity,
+      onGround: isOnGround,
+      isSneaking: gameAdditionalState.isSneaking,
+      isFlying: gameAdditionalState.isFlying,
+      timeOffGround: this.timeOffGround,
+      deltaTime,
+    })
+    this.timeOffGround = next.timeOffGround
+    this.reactive.movementState = next.movementState
   }
 
   private updateWalkDistAndBob () {
@@ -256,20 +247,19 @@ export class PlayerStateControllerMain {
 
     const { velocity } = bot.entity
     const horizontalDist = Math.hypot(velocity.x, velocity.z)
-
-    // Save previous values for interpolation
-    this.reactive.prevWalkDist = this.reactive.walkDist
-    this.reactive.prevBob = this.reactive.bob
-
-    // Accumulate walk distance with dampening factor
-    this.reactive.walkDist += horizontalDist * 0.6
-
-    // Smooth bob amplitude — vanilla: onGround && !isDeadOrDying && !isSwimming
-    // isSwimming = sprinting + in water (not just touching water)
-    const isSwimming = bot.controlState.sprint && this.reactive.inWater
-    const isDeadOrDying = (bot.entity.health ?? 20) <= 0
-    const bobTarget = (bot.entity.onGround && !isDeadOrDying && !isSwimming) ? Math.min(0.1, horizontalDist) : 0
-    this.reactive.bob += (bobTarget - this.reactive.bob) * 0.4
+    const next = updateMountedBobState({
+      mounted: Boolean(bot.vehicle),
+      walkDist: this.reactive.walkDist,
+      bob: this.reactive.bob,
+      horizontalDist,
+      onGround: bot.entity.onGround,
+      isDeadOrDying: (bot.entity.health ?? 20) <= 0,
+      isSwimming: bot.controlState.sprint && this.reactive.inWater,
+    })
+    this.reactive.prevWalkDist = next.prevWalkDist
+    this.reactive.prevBob = next.prevBob
+    this.reactive.walkDist = next.walkDist
+    this.reactive.bob = next.bob
   }
 
   // #region Held Item State

--- a/src/mineflayer/plugins/mouse.ts
+++ b/src/mineflayer/plugins/mouse.ts
@@ -47,6 +47,7 @@ function cursorBlockDisplay (bot: Bot) {
 export default (bot: Bot) => {
   bot.loadPlugin(createMouse({
     useMineflayerInteractMethods: false,
+    preventVehicleInteraction: false,
   }))
 
   domListeners(bot)

--- a/src/mountedPlayerState.test.ts
+++ b/src/mountedPlayerState.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from 'vitest'
+import { updateMountedBobState, updateMountedMovementState } from './mountedPlayerState'
+
+const movingBobInput = {
+  mounted: false,
+  walkDist: 2,
+  bob: 0,
+  horizontalDist: 0.2,
+  onGround: true,
+  isDeadOrDying: false,
+  isSwimming: false,
+}
+
+test('walking player continues accumulating distance and bob', () => {
+  const next = updateMountedBobState(movingBobInput)
+  expect(next.prevWalkDist).toBe(2)
+  expect(next.prevBob).toBe(0)
+  expect(next.walkDist).toBeCloseTo(2.12)
+  expect(next.bob).toBeCloseTo(0.04)
+})
+
+test.each(['horse', 'boat', 'minecart'])('mounted %s keeps speed out of bob state', (vehicle) => {
+  const next = updateMountedBobState({
+    ...movingBobInput,
+    mounted: true,
+    walkDist: 5,
+    bob: 0.08,
+  })
+  expect(next.walkDist).toBe(5)
+  expect(next.bob).toBe(0)
+  expect(vehicle).toBeTruthy()
+})
+
+test('mounting clears an already non-zero bob in one tick', () => {
+  const next = updateMountedBobState({ ...movingBobInput, mounted: true, bob: 0.09 })
+  expect(next.prevBob).toBe(0.09)
+  expect(next.bob).toBe(0)
+})
+
+test('mounted player selects NOT_MOVING and resets airborne movement timer', () => {
+  expect(updateMountedMovementState({
+    mounted: true,
+    velocity: { x: 1, z: 1 },
+    onGround: false,
+    isSneaking: true,
+    isFlying: false,
+    timeOffGround: 100,
+    deltaTime: 50,
+  })).toEqual({ movementState: 'NOT_MOVING', timeOffGround: 0 })
+})
+
+test('dismounted player resumes ordinary movement state detection', () => {
+  expect(updateMountedMovementState({
+    mounted: false,
+    velocity: { x: 0.2, z: 0 },
+    onGround: true,
+    isSneaking: false,
+    isFlying: false,
+    timeOffGround: 100,
+    deltaTime: 50,
+  })).toEqual({ movementState: 'SPRINTING', timeOffGround: 0 })
+})

--- a/src/mountedPlayerState.ts
+++ b/src/mountedPlayerState.ts
@@ -1,0 +1,81 @@
+import type { MovementState } from 'minecraft-renderer/src/playerState/types'
+
+export type MountedBobStateInput = {
+  mounted: boolean
+  walkDist: number
+  bob: number
+  horizontalDist: number
+  onGround: boolean
+  isDeadOrDying: boolean
+  isSwimming: boolean
+}
+
+export type MountedBobState = {
+  prevWalkDist: number
+  prevBob: number
+  walkDist: number
+  bob: number
+}
+
+export function updateMountedBobState (input: MountedBobStateInput): MountedBobState {
+  const { mounted, walkDist, bob, horizontalDist, onGround, isDeadOrDying, isSwimming } = input
+
+  if (mounted) {
+    return {
+      prevWalkDist: walkDist,
+      prevBob: bob,
+      walkDist,
+      bob: 0,
+    }
+  }
+
+  const nextWalkDist = walkDist + horizontalDist * 0.6
+  const bobTarget = (onGround && !isDeadOrDying && !isSwimming) ? Math.min(0.1, horizontalDist) : 0
+  return {
+    prevWalkDist: walkDist,
+    prevBob: bob,
+    walkDist: nextWalkDist,
+    bob: bob + (bobTarget - bob) * 0.4,
+  }
+}
+
+export type MountedMovementStateInput = {
+  mounted: boolean
+  velocity: { x: number, z: number }
+  onGround: boolean
+  isSneaking: boolean
+  isFlying: boolean
+  timeOffGround: number
+  deltaTime: number
+}
+
+export type MountedMovementState = {
+  movementState: MovementState
+  timeOffGround: number
+}
+
+export function updateMountedMovementState (input: MountedMovementStateInput): MountedMovementState {
+  const { mounted, velocity, onGround, isSneaking, isFlying, timeOffGround, deltaTime } = input
+
+  if (mounted) {
+    return { movementState: 'NOT_MOVING', timeOffGround: 0 }
+  }
+
+  const nextTimeOffGround = onGround ? 0 : timeOffGround + deltaTime
+  if (isSneaking || isFlying || nextTimeOffGround > 0) {
+    return { movementState: 'SNEAKING', timeOffGround: nextTimeOffGround }
+  }
+
+  const velocityThreshold = 0.01
+  const sprintingVelocity = 0.15
+  if (Math.abs(velocity.x) > velocityThreshold || Math.abs(velocity.z) > velocityThreshold) {
+    return {
+      movementState: Math.abs(velocity.x) > sprintingVelocity || Math.abs(velocity.z) > sprintingVelocity
+        ? 'SPRINTING'
+        : 'WALKING',
+      timeOffGround: nextTimeOffGround,
+    }
+  }
+
+  return { movementState: 'NOT_MOVING', timeOffGround: nextTimeOffGround }
+}


### PR DESCRIPTION
## Integrate controlled vehicle physics and rendering

### Context

This PR connects the Mineflayer vehicle simulation to the renderer and enables
mounted vehicle interaction in the browser client.

It is the integration layer for the related physics, Mineflayer, and renderer
PRs, covering boats, horses, and minecarts.

### Implementation

#### Vehicle interaction

- Allow mouse interaction with vehicle entities so players can mount and control
  vehicles (boats and horses; minecarts are server-driven).
- Enable interaction and controls while mounted.

#### Renderer hints

- Mark the player's current vehicle as the local vehicle.
- Forward a passenger layout per vehicle type (`boat` / `minecart` / `horse`)
  and the passenger IDs so the renderer can seat riders.
- Boats:
  - forward authoritative local boat status from Mineflayer;
  - derive water-patch visibility for local boats from physics status and for
    remote boats from world blocks;
  - hide the patch for submerged boats, flowing-water cover, land, waterlogged
    solid blocks, and unloaded world data.
- Horses: request a vertical camera lock while the player is actively
  controlling the horse.
- Minecarts: forward riding state and select a server-driven camera movement
  mode (`server-vehicle`), keeping the local-player mode otherwise.
- Forward the resulting hints with renderer entity updates.

#### Passenger rendering

- Stabilize mounted-player rendering.
- Add a rider movement-animation state (mounted/riding) so seated players are
  animated consistently.

#### Diagnostics

- Expose `BOAT_PHYS_DEBUG` to browser builds for live controlled-boat
  diagnostics.

#### Build correctness

- Declare `glob` and `ws` as direct dependencies because client scripts import
  them directly.
- Migrate `scripts/build.js` to the `glob@10` `globSync` API.

Previously these packages were available only through incidental pnpm transitive
hoisting. Changing the dependency graph for local `file:` development exposed
that undeclared dependency.

### Testing

- `src/boatRenderHints.test.ts` — 20 passing tests.
- `src/cameraMovementMode.test.ts` — 2 passing tests.
- `src/entityMovementAnimation.test.ts` — 7 passing tests.
- Coverage includes:
  - every local `BoatStatus`;
  - source and flowing water; submerged and on-land boats; waterlogged blocks;
    unloaded world data; local versus remote vehicle hints;
  - boat / minecart / horse passenger layouts and horse camera lock;
  - minecart server-vehicle camera mode;
  - rider movement-animation states.
- Full Minecraft 1.17.1 browser validation covered:
  - mounting and controls (boat and horse);
  - sustained acceleration; input press and release;
  - third-person alignment; server corrections;
  - boat water masking;
  - minecart riding.

### Version support

The client itself has no version gate; it forwards whatever the physics,
Mineflayer, and renderer layers support and was validated on Minecraft 1.17.1.
The 1.17.1 limit for locally controlled boats and horses comes from Mineflayer
(vehicle control protocol and boat physics model); minecart riding is
server-authoritative and version-neutral.

### Dependencies

This PR should merge after the following PRs are merged and released or otherwise
made available to the client:

- [nxg-org/mineflayer-physics-utils#56](https://github.com/nxg-org/mineflayer-physics-utils/pull/56)
- [zardoy/mineflayer#9](https://github.com/zardoy/mineflayer/pull/9)
- [zardoy/minecraft-renderer#85](https://github.com/zardoy/minecraft-renderer/pull/85)

### Merge order

1. `mineflayer-physics-utils`
2. `mineflayer` and `minecraft-renderer`
3. `minecraft-web-client`
