### PR TITLE
Fixed: disabled blockPlacePrediction + foreground dim for player windows.

### DIFF
--- a/src/appViewer.ts
+++ b/src/appViewer.ts
@@ -82,6 +82,20 @@ export const onAppViewerConfigUpdate = () => {
   appViewer.inWorldRenderingConfig.skinTexturesProxy = miscUiState.appConfig?.skinTexturesProxy
 }
 
+const foregroundBlockingModalTypes = new Set([
+  'pause-screen',
+  'console',
+  'chunks-debug',
+  'renderer-debug',
+  'bed',
+])
+
+const shouldBlockForeground = (reactType: string) => {
+  if (reactType.startsWith('player_win:') || reactType === 'chat' || reactType === 'full-map' || reactType === 'app-status') return false
+  if (reactType.startsWith('options-')) return true
+  return foregroundBlockingModalTypes.has(reactType)
+}
+
 export const modalStackUpdateChecks = () => {
   if (!miscUiState.gameLoaded && !hasAppStatus()) {
     void initialMenuStart()
@@ -91,7 +105,8 @@ export const modalStackUpdateChecks = () => {
     appViewer.backend.setRendering(!hasAppStatus())
   }
 
-  appViewer.inWorldRenderingConfig.foreground = activeModalStack.length === 0
+  const hasBlockingForeground = activeModalStack.some(m => shouldBlockForeground(m.reactType))
+  appViewer.inWorldRenderingConfig.foreground = !hasBlockingForeground
 }
 subscribe(activeModalStack, modalStackUpdateChecks)
 

--- a/src/mineflayer/plugins/mouse.ts
+++ b/src/mineflayer/plugins/mouse.ts
@@ -47,6 +47,7 @@ function cursorBlockDisplay (bot: Bot) {
 export default (bot: Bot) => {
   bot.loadPlugin(createMouse({
     useMineflayerInteractMethods: false,
+    blockPlacePrediction: false,
   }))
 
   domListeners(bot)


### PR DESCRIPTION
Root Cause Analysis
The bug had two components:

Block placement prediction corruption (mineflayer-mouse): When right-clicking a block, blockPlacePrediction (enabled by default) would predictively modify the local world state. For non-block items on non-interactive blocks, this prediction would run but produce incorrect local block states, making blocks appear transparent. This also caused a double-action where both block_place (use_item_on) and use_item packets were sent for every right-click, confusing the server.

Foreground dimming for player windows (appViewer.ts): The foreground rendering flag was set to false whenever ANY modal was open (including player windows like crafting tables, chests, inventory). This caused the renderer to dim/make the world transparent behind the GUI, which users perceived as an X-ray effect.

Changes Made
1. src/mineflayer/plugins/mouse.ts (line 50)
Added blockPlacePrediction: false to the mouse plugin config:

bot.loadPlugin(createMouse({
    useMineflayerInteractMethods: false,
    blockPlacePrediction: false,
}))
This prevents the client from predictively modifying block states on right-click, eliminating the most common source of block state corruption.

2. src/appViewer.ts (lines 85-109)
Changed the foreground flag logic to only dim the world for non-player-window modals (pause menu, options, console, etc.), matching vanilla Minecraft behavior where the world remains fully visible behind player windows:

const shouldBlockForeground = (reactType: string) => {
    if (reactType.startsWith('player_win:') || reactType === 'chat' || reactType === 'full-map' || reactType === 'app-status') return false
    if (reactType.startsWith('options-')) return true
    return foregroundBlockingModalTypes.has(reactType)
}
and i think i can fix the ussue this: https://github.com/zardoy/minecraft-web-client/issues/571