### PR TITLE
fix: point the Smart Cull button at the real renderer option

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:cypress": "cypress run",
     "test:benchmark": "PERFORMANCE_TEST=true cypress run",
     "test:cypress:open": "cypress open",
-    "test-unit": "vitest",
+    "test-unit": "vitest run",
     "test:e2e": "start-test http-get://localhost:8080 test:cypress",
     "prod-start": "node server.js --prod",
     "test-mc-server": "tsx cypress/minecraft-server.mjs",

--- a/src/defaultOptions.ts
+++ b/src/defaultOptions.ts
@@ -38,6 +38,7 @@ export const defaultOptions = {
   debugLogNotFrequentPackets: false,
   unimplementedContainers: false,
   ...RENDERER_DEFAULT_OPTIONS,
+  rendererSmartCull: false as boolean,
   enabledResourcepack: null as string | null,
   useVersionsTextures: 'latest',
   serverResourcePacks: 'prompt' as 'prompt' | 'always' | 'never',
@@ -204,6 +205,10 @@ export type OptionMeta = {
 
 export const optionsMeta: Partial<Record<keyof typeof defaultOptions, OptionMeta>> = {
   ...RENDERER_OPTIONS_META,
+  rendererSmartCull: {
+    text: 'Smart cull',
+    tooltip: 'Occlusion-based section culling for better performance in caves and enclosed spaces',
+  },
   activeRenderer: {
     possibleValues: [
       ['threejs', 'Three.js (stable)'],

--- a/src/optionsGuiScheme.tsx
+++ b/src/optionsGuiScheme.tsx
@@ -164,6 +164,10 @@ export const guiOptionsScheme: {
       rendererPerfDebugOverlay: {
         text: 'Performance Debug',
       },
+      rendererSmartCull: {
+        text: 'Smart cull',
+        tooltip: 'Occlusion-based section culling for better performance in caves and enclosed spaces',
+      },
     },
     {
       custom () {

--- a/src/react/RendererDebugMenu.tsx
+++ b/src/react/RendererDebugMenu.tsx
@@ -14,9 +14,9 @@ export default () => {
 
 const RendererDebugMenu = ({ worldRenderer }: { worldRenderer: WorldRendererCommon }) => {
   const { reactiveDebugParams } = worldRenderer
-  const { chunksRenderAboveEnabled, chunksRenderBelowEnabled, chunksRenderDistanceEnabled, chunksRenderAboveOverride, chunksRenderBelowOverride, chunksRenderDistanceOverride, stopRendering, disableEntities, caveCullingDebug, smartCull } = useSnapshot(reactiveDebugParams)
+  const { chunksRenderAboveEnabled, chunksRenderBelowEnabled, chunksRenderDistanceEnabled, chunksRenderAboveOverride, chunksRenderBelowOverride, chunksRenderDistanceOverride, stopRendering, disableEntities, caveCullingDebug } = useSnapshot(reactiveDebugParams)
 
-  const { rendererPerfDebugOverlay } = useSnapshot(options)
+  const { rendererPerfDebugOverlay, rendererSmartCull } = useSnapshot(options)
 
   // Helper to round values to nearest step
   const roundToStep = (value: number, step: number) => Math.round(value / step) * step
@@ -37,9 +37,9 @@ const RendererDebugMenu = ({ worldRenderer }: { worldRenderer: WorldRendererComm
         overlayColor={disableEntities ? 'red' : undefined}
       />
       <Button
-        label={smartCull ? 'Disable Smart Cull' : 'Enable Smart Cull'}
-        onClick={() => { reactiveDebugParams.smartCull = !smartCull }}
-        overlayColor={smartCull ? undefined : 'orange'}
+        label={rendererSmartCull ? 'Disable Smart Cull' : 'Enable Smart Cull'}
+        onClick={() => { options.rendererSmartCull = !rendererSmartCull }}
+        overlayColor={rendererSmartCull ? undefined : 'orange'}
       />
       <Button
         label={caveCullingDebug ? 'Hide Cave Cull Debug' : 'Show Cave Cull Debug'}

--- a/src/watchOptions.ts
+++ b/src/watchOptions.ts
@@ -46,6 +46,14 @@ export const watchOptionsAfterViewerInit = () => {
     appViewer.inWorldRenderingConfig.volume = Math.max(o.volume / 100, 0)
   })
 
+  watchValue(options, o => {
+    appViewer.inWorldRenderingConfig.smartCull = o.rendererSmartCull
+    const worldRenderer = window.world
+    if (worldRenderer) {
+      worldRenderer.reactiveDebugParams.smartCull = true
+    }
+  })
+
   subscribeKey(options, 'newVersionsLighting', () => {
     applyRendererEnableLighting(
       appViewer,


### PR DESCRIPTION
The button flipped `reactiveDebugParams.smartCull`, one half of an AND whose other half (`worldRendererConfig.smartCull`) had no UI and defaulted to `false`, so the feature could only be turned on from the console. The renderer release replaces both with a single persisted `rendererSmartCull` option; the button now writes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Smart cull” renderer setting, disabled by default.
  * Added an explanatory tooltip describing occlusion-based section culling.
  * Smart culling now synchronizes with active world rendering settings.

* **Bug Fixes**
  * Fixed the renderer debug menu’s Smart Cull toggle so it correctly reflects and updates active renderer settings.
  * Preserved existing behavior for other renderer debugging options.

* **Tests**
  * Unit tests now run in single-run mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->